### PR TITLE
templates for pull requests and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A concise description of what the bug is.
+
+**Steps to reproduce**
+
+**Expected outcome**
+A concise description of what you expected to happen.
+
+**Environment**
+
+* Kubernetes version
+* Using EKS (yes/no), if so version?
+* ElastiCahce controller version?
+* ElastiCahce controller Custom Resource version?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem?**
+A description of what the problem is. For example: I'm frustrated when [...]
+
+**Describe the solution you'd like**
+A description of what you want to happen.
+
+**Describe alternatives you've considered**
+A description of any alternative solutions or features you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Issue #, if available:
+
+Description of changes:
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
Issue #, if available:

The repository does not contain templates for the pull requests and issues.

Description of changes:

Added templates for pull requests and issues (similar to `community`, `code-generator` modules).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
