### PR TITLE
Allow reference to local runtime module using local go mod file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+go.local.sum
 /docs/site
 bin
 build

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ all: test
 test: 				## Run code tests
 	go test -v ./...
 
+local-test: 		## Run code tests using go.local.mod file
+	go test -modfile=go.local.mod -v ./...
+
 help:           	## Show this help.
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
 		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'

--- a/go.local.mod
+++ b/go.local.mod
@@ -1,0 +1,20 @@
+module github.com/aws-controllers-k8s/elasticache-controller
+
+go 1.14
+
+replace github.com/aws-controllers-k8s/runtime => ../runtime
+
+require (
+	github.com/aws-controllers-k8s/runtime v0.0.0-20210204203051-91a6bd53a48c
+	github.com/aws/aws-sdk-go v1.37.4
+	github.com/go-logr/logr v0.1.0
+	github.com/google/go-cmp v0.3.1
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.5.1
+	go.uber.org/zap v1.10.0
+	k8s.io/api v0.18.2
+	k8s.io/apimachinery v0.18.6
+	k8s.io/client-go v0.18.2
+	sigs.k8s.io/controller-runtime v0.6.0
+)


### PR DESCRIPTION
Issue #, if available:

During development, workspace directory setup looks like:
Example setup including ElastiCache service controller along with ACK packages:
```
aws-controllers-k8s
├── code-generator
├── community
├── elasticache-controller
└── runtime
```
To build service controller image against local changes in ```runtime``` module, create`elasticache-controller/go.local.mod` file with `replace`:
```
replace github.com/aws-controllers-k8s/runtime => ../runtime
```
Also support `make local-test` to run local unit tests using local `runtime` module.

Related PR in `community` module: https://github.com/aws-controllers-k8s/community/pull/682

Description of changes:

* Added `elasticache-controller/go.local.mod`
* Added `elasticache-controller/go.local.sum` to `.gitignore`
* Added `make local-test` target.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
