### PR TITLE
AuthToken - Use SecretRef

### DIFF
--- a/apis/v1alpha1/replication_group.go
+++ b/apis/v1alpha1/replication_group.go
@@ -22,27 +22,27 @@ import (
 
 // ReplicationGroupSpec defines the desired state of ReplicationGroup
 type ReplicationGroupSpec struct {
-	AtRestEncryptionEnabled    *bool                     `json:"atRestEncryptionEnabled,omitempty"`
-	AuthToken                  *string                   `json:"authToken,omitempty"`
-	AutoMinorVersionUpgrade    *bool                     `json:"autoMinorVersionUpgrade,omitempty"`
-	AutomaticFailoverEnabled   *bool                     `json:"automaticFailoverEnabled,omitempty"`
-	CacheNodeType              *string                   `json:"cacheNodeType,omitempty"`
-	CacheParameterGroupName    *string                   `json:"cacheParameterGroupName,omitempty"`
-	CacheSecurityGroupNames    []*string                 `json:"cacheSecurityGroupNames,omitempty"`
-	CacheSubnetGroupName       *string                   `json:"cacheSubnetGroupName,omitempty"`
-	Engine                     *string                   `json:"engine,omitempty"`
-	EngineVersion              *string                   `json:"engineVersion,omitempty"`
-	KMSKeyID                   *string                   `json:"kmsKeyID,omitempty"`
-	MultiAZEnabled             *bool                     `json:"multiAZEnabled,omitempty"`
-	NodeGroupConfiguration     []*NodeGroupConfiguration `json:"nodeGroupConfiguration,omitempty"`
-	NotificationTopicARN       *string                   `json:"notificationTopicARN,omitempty"`
-	NumCacheClusters           *int64                    `json:"numCacheClusters,omitempty"`
-	NumNodeGroups              *int64                    `json:"numNodeGroups,omitempty"`
-	Port                       *int64                    `json:"port,omitempty"`
-	PreferredCacheClusterAZs   []*string                 `json:"preferredCacheClusterAZs,omitempty"`
-	PreferredMaintenanceWindow *string                   `json:"preferredMaintenanceWindow,omitempty"`
-	PrimaryClusterID           *string                   `json:"primaryClusterID,omitempty"`
-	ReplicasPerNodeGroup       *int64                    `json:"replicasPerNodeGroup,omitempty"`
+	AtRestEncryptionEnabled    *bool                           `json:"atRestEncryptionEnabled,omitempty"`
+	AuthToken                  *ackv1alpha1.SecretKeyReference `json:"authToken,omitempty"`
+	AutoMinorVersionUpgrade    *bool                           `json:"autoMinorVersionUpgrade,omitempty"`
+	AutomaticFailoverEnabled   *bool                           `json:"automaticFailoverEnabled,omitempty"`
+	CacheNodeType              *string                         `json:"cacheNodeType,omitempty"`
+	CacheParameterGroupName    *string                         `json:"cacheParameterGroupName,omitempty"`
+	CacheSecurityGroupNames    []*string                       `json:"cacheSecurityGroupNames,omitempty"`
+	CacheSubnetGroupName       *string                         `json:"cacheSubnetGroupName,omitempty"`
+	Engine                     *string                         `json:"engine,omitempty"`
+	EngineVersion              *string                         `json:"engineVersion,omitempty"`
+	KMSKeyID                   *string                         `json:"kmsKeyID,omitempty"`
+	MultiAZEnabled             *bool                           `json:"multiAZEnabled,omitempty"`
+	NodeGroupConfiguration     []*NodeGroupConfiguration       `json:"nodeGroupConfiguration,omitempty"`
+	NotificationTopicARN       *string                         `json:"notificationTopicARN,omitempty"`
+	NumCacheClusters           *int64                          `json:"numCacheClusters,omitempty"`
+	NumNodeGroups              *int64                          `json:"numNodeGroups,omitempty"`
+	Port                       *int64                          `json:"port,omitempty"`
+	PreferredCacheClusterAZs   []*string                       `json:"preferredCacheClusterAZs,omitempty"`
+	PreferredMaintenanceWindow *string                         `json:"preferredMaintenanceWindow,omitempty"`
+	PrimaryClusterID           *string                         `json:"primaryClusterID,omitempty"`
+	ReplicasPerNodeGroup       *int64                          `json:"replicasPerNodeGroup,omitempty"`
 	// +kubebuilder:validation:Required
 	ReplicationGroupDescription *string `json:"replicationGroupDescription"`
 	// +kubebuilder:validation:Required

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1797,7 +1797,7 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 	}
 	if in.AuthToken != nil {
 		in, out := &in.AuthToken, &out.AuthToken
-		*out = new(string)
+		*out = new(corev1alpha1.SecretKeyReference)
 		**out = **in
 	}
 	if in.AutoMinorVersionUpgrade != nil {

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -39,7 +39,23 @@ spec:
               atRestEncryptionEnabled:
                 type: boolean
               authToken:
-                type: string
+                description: SecretKeyReference combines a k8s corev1.SecretReference
+                  with a specific key within the referred-to Secret
+                properties:
+                  key:
+                    description: Key is the key within the secret
+                    type: string
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                required:
+                - key
+                type: object
               autoMinorVersionUpgrade:
                 type: boolean
               automaticFailoverEnabled:

--- a/generator.yaml
+++ b/generator.yaml
@@ -53,6 +53,8 @@ resources:
         from:
           operation: DescribeEvents
           path: Events
+      AuthToken:
+        is_secret: true
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/elasticache-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.0-20210204203051-91a6bd53a48c
+	github.com/aws-controllers-k8s/runtime v0.0.4-0.20210302233800-cbda0dfbbca3
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/runtime v0.0.0-20210204203051-91a6bd53a48c h1:0hHYJ3fVDLSnENSFlYxrajjpFOehEnzYPiX1VIWB4Xw=
 github.com/aws-controllers-k8s/runtime v0.0.0-20210204203051-91a6bd53a48c/go.mod h1:ZENN/6/CjjeUNVEhli84fDgkxDw21zsm7xtzHuCJAGg=
+github.com/aws-controllers-k8s/runtime v0.0.4-0.20210302233800-cbda0dfbbca3 h1:vfdS1CI6OKReRN+wxl7W/J2LVhyNVVT97IeYptnRqXw=
+github.com/aws-controllers-k8s/runtime v0.0.4-0.20210302233800-cbda0dfbbca3/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-controllers-k8s v0.0.2 h1:6NzkBLnBFWG8+UlDwZcLun5sLm14c+3yLfRxnZUIgnA=
 github.com/aws/aws-controllers-k8s v0.0.2/go.mod h1:BHGW5NrZT1Ue8mOD964l++247XJzyzwKwB8Tg/Cub0U=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=

--- a/pkg/resource/cache_parameter_group/sdk.go
+++ b/pkg/resource/cache_parameter_group/sdk.go
@@ -123,7 +123,7 @@ func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(r)
+	input, err := rm.newCreateRequestPayload(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -162,6 +162,7 @@ func (rm *resourceManager) sdkCreate(
 // newCreateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Create API call for the resource
 func (rm *resourceManager) newCreateRequestPayload(
+	ctx context.Context,
 	r *resource,
 ) (*svcsdk.CreateCacheParameterGroupInput, error) {
 	res := &svcsdk.CreateCacheParameterGroupInput{}

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -145,7 +145,7 @@ func (rm *resourceManager) sdkCreate(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
-	input, err := rm.newCreateRequestPayload(r)
+	input, err := rm.newCreateRequestPayload(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -203,6 +203,7 @@ func (rm *resourceManager) sdkCreate(
 // newCreateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Create API call for the resource
 func (rm *resourceManager) newCreateRequestPayload(
+	ctx context.Context,
 	r *resource,
 ) (*svcsdk.CreateCacheSubnetGroupInput, error) {
 	res := &svcsdk.CreateCacheSubnetGroupInput{}
@@ -235,7 +236,7 @@ func (rm *resourceManager) sdkUpdate(
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 
-	input, err := rm.newUpdateRequestPayload(desired)
+	input, err := rm.newUpdateRequestPayload(ctx, desired)
 	if err != nil {
 		return nil, err
 	}
@@ -293,6 +294,7 @@ func (rm *resourceManager) sdkUpdate(
 // newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Update API call for the resource
 func (rm *resourceManager) newUpdateRequestPayload(
+	ctx context.Context,
 	r *resource,
 ) (*svcsdk.ModifyCacheSubnetGroupInput, error) {
 	res := &svcsdk.ModifyCacheSubnetGroupInput{}

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -253,7 +253,7 @@ func (rm *resourceManager) sdkCreate(
 	if customResp != nil || customRespErr != nil {
 		return customResp, customRespErr
 	}
-	input, err := rm.newCreateRequestPayload(r)
+	input, err := rm.newCreateRequestPayload(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -415,6 +415,7 @@ func (rm *resourceManager) sdkCreate(
 // newCreateRequestPayload returns an SDK-specific struct for the HTTP request
 // payload of the Create API call for the resource
 func (rm *resourceManager) newCreateRequestPayload(
+	ctx context.Context,
 	r *resource,
 ) (*svcsdk.CreateSnapshotInput, error) {
 	res := &svcsdk.CreateSnapshotInput{}


### PR DESCRIPTION
- Update AuthToken to use SecretKeyRef.
- Automatically generated, depends upon
- Runtime code changes.

Other PRs -
Codegen gen - https://github.com/aws-controllers-k8s/code-generator/pull/21
Runtime changes - https://github.com/aws-controllers-k8s/runtime/pull/5

New test payload.

```
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: ReplicationGroup
metadata:
  name: testing
spec:
    engine: redis
    replicationGroupID: testing
    replicationGroupDescription: Test replication group
    cacheNodeType: cache.t3.micro
    numNodeGroups: 2
    replicasPerNodeGroup: 2
    authToken:
      name: test-secret
      key: auth
    transitEncryptionEnabled: true
    cacheSubnetGroupName: default
````

Probably would require runtime PR to be merged before merging this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
