### PR TITLE
mock api output from json file for unit tests

### DIFF
--- a/pkg/resource/replication_group/custom_update_api_test.go
+++ b/pkg/resource/replication_group/custom_update_api_test.go
@@ -16,11 +16,13 @@ package replication_group
 import (
 	"context"
 	"fmt"
+	"github.com/aws-controllers-k8s/elasticache-controller/pkg/testutil"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap/zapcore"
+	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"testing"
 
@@ -264,11 +266,8 @@ func TestDecreaseReplicaCountMock(t *testing.T) {
 	assert := assert.New(t)
 	// Setup mock API response
 	var mockReplicationGroupDescription = "mock_replication_group_description"
-	var mockOutput = svcsdk.DecreaseReplicaCountOutput{
-		ReplicationGroup: &svcsdk.ReplicationGroup{
-			Description: &mockReplicationGroupDescription,
-		},
-	}
+	var mockOutput svcsdk.DecreaseReplicaCountOutput
+	testutil.LoadFromFixture(filepath.Join("testdata", "DecreaseReplicaCountOutput.json"), &mockOutput)
 	mocksdkapi := &mocksvcsdkapi.ElastiCacheAPI{}
 	mocksdkapi.On("DecreaseReplicaCountWithContext", mock.Anything, mock.Anything).Return(&mockOutput, nil)
 	rm := provideResourceManagerWithMockSDKAPI(mocksdkapi)

--- a/pkg/resource/replication_group/testdata/DecreaseReplicaCountOutput.json
+++ b/pkg/resource/replication_group/testdata/DecreaseReplicaCountOutput.json
@@ -1,0 +1,77 @@
+{
+  "ReplicationGroup": {
+    "ReplicationGroupId": "my-cluster",
+    "Description": "mock_replication_group_description",
+    "Status": "modifying",
+    "PendingModifiedValues": {},
+    "MemberClusters": [
+      "myrepliace",
+      "my-cluster-001",
+      "my-cluster-002",
+      "my-cluster-003"
+    ],
+    "NodeGroups": [
+      {
+        "NodeGroupId": "0001",
+        "Status": "modifying",
+        "PrimaryEndpoint": {
+          "Address": "my-cluster.xxxxx.ng.0001.usw2.cache.amazonaws.com",
+          "Port": 6379
+        },
+        "ReaderEndpoint": {
+          "Address": "my-cluster-ro.xxxxx.ng.0001.usw2.cache.amazonaws.com",
+          "Port": 6379
+        },
+        "NodeGroupMembers": [
+          {
+            "CacheClusterId": "myrepliace",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Address": "myrepliace.xxxxx.0001.usw2.cache.amazonaws.com",
+              "Port": 6379
+            },
+            "PreferredAvailabilityZone": "us-west-2a",
+            "CurrentRole": "replica"
+          },
+          {
+            "CacheClusterId": "my-cluster-001",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Address": "my-cluster-001.xxxxx.0001.usw2.cache.amazonaws.com",
+              "Port": 6379
+            },
+            "PreferredAvailabilityZone": "us-west-2a",
+            "CurrentRole": "primary"
+          },
+          {
+            "CacheClusterId": "my-cluster-002",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Address": "my-cluster-002.xxxxx.0001.usw2.cache.amazonaws.com",
+              "Port": 6379
+            },
+            "PreferredAvailabilityZone": "us-west-2a",
+            "CurrentRole": "replica"
+          },
+          {
+            "CacheClusterId": "my-cluster-003",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Address": "my-cluster-003.xxxxx.0001.usw2.cache.amazonaws.com",
+              "Port": 6379
+            },
+            "PreferredAvailabilityZone": "us-west-2a",
+            "CurrentRole": "replica"
+          }
+        ]
+      }
+    ],
+    "AutomaticFailover": "disabled",
+    "SnapshotRetentionLimit": 0,
+    "SnapshotWindow": "07:30-08:30",
+    "ClusterEnabled": false,
+    "CacheNodeType": "cache.r5.xlarge",
+    "TransitEncryptionEnabled": false,
+    "AtRestEncryptionEnabled": false
+  }
+}

--- a/pkg/resource/replication_group/testdata/DescribeReplicationGroupsOutput.json
+++ b/pkg/resource/replication_group/testdata/DescribeReplicationGroupsOutput.json
@@ -1,0 +1,80 @@
+{
+  "ReplicationGroups": [
+    {
+      "ReplicationGroupId": "my-cluster",
+      "Description": "mycluster",
+      "Status": "available",
+      "PendingModifiedValues": {},
+      "MemberClusters": [
+        "pat-cluster-001",
+        "pat-cluster-002",
+        "pat-cluster-003",
+        "pat-cluster-004"
+      ],
+      "NodeGroups": [
+        {
+          "NodeGroupId": "0001",
+          "Status": "available",
+          "PrimaryEndpoint": {
+            "Address": "my-cluster.xxxxih.ng.0001.usw2.cache.amazonaws.com",
+            "Port": 6379
+          },
+          "ReaderEndpoint": {
+            "Address": "my-cluster-ro.xxxxih.ng.0001.usw2.cache.amazonaws.com",
+            "Port": 6379
+          },
+          "NodeGroupMembers": [
+            {
+              "CacheClusterId": "my-cluster-001",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Address": "pat-cluster-001.xxxih.0001.usw2.cache.amazonaws.com",
+                "Port": 6379
+              },
+              "PreferredAvailabilityZone": "us-west-2a",
+              "CurrentRole": "primary"
+            },
+            {
+              "CacheClusterId": "my-cluster-002",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Address": "pat-cluster-002.xxxxih.0001.usw2.cache.amazonaws.com",
+                "Port": 6379
+              },
+              "PreferredAvailabilityZone": "us-west-2a",
+              "CurrentRole": "replica"
+            },
+            {
+              "CacheClusterId": "my-cluster-003",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Address": "pat-cluster-003.xxxxih.0001.usw2.cache.amazonaws.com",
+                "Port": 6379
+              },
+              "PreferredAvailabilityZone": "us-west-2a",
+              "CurrentRole": "replica"
+            },
+            {
+              "CacheClusterId": "my-cluster-004",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Address": "pat-cluster-004.xxxih.0001.usw2.cache.amazonaws.com",
+                "Port": 6379
+              },
+              "PreferredAvailabilityZone": "us-west-2a",
+              "CurrentRole": "replica"
+            }
+          ]
+        }
+      ],
+      "AutomaticFailover": "disabled",
+      "SnapshotRetentionLimit": 0,
+      "SnapshotWindow": "07:30-08:30",
+      "ClusterEnabled": false,
+      "CacheNodeType": "cache.r5.xlarge",
+      "AuthTokenEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false
+    }
+  ]
+}

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -1,0 +1,35 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutil
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+// LoadFromFixture fills an empty pointer variable with the
+// data from a fixture JSON file.
+func LoadFromFixture(
+	fixturePath string,
+	output interface{}, // output should be an addressable type (i.e. a pointer)
+) {
+	contents, err := ioutil.ReadFile(fixturePath)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(contents, output)
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR adds methods to create mock ElastiCache API output from json file.
This would help unit test scenarios by adding corresponding API response json from file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
