### PR TITLE
option to generate coverage details during unit tests

### DIFF
--- a/.github/workflows/unit-test-cover.yaml
+++ b/.github/workflows/unit-test-cover.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: make test
+    name: make test cover
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
@@ -21,5 +21,5 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.15'
-      - name: make test
-        run: make test
+      - name: make test cover
+        run: make test-cover

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 .idea
 go.local.sum
+coverage.out
 /docs/site
 bin
 build

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ all: test
 test: | mocks				## Run code tests
 	go test -v ./...
 
+test-cover: | mocks				## Run code tests with resources coverage
+	go test -coverpkg=./pkg/resource/... -covermode=count -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
 local-test: | mocks		## Run code tests using go.local.mod file
 	go test -modfile=go.local.mod -v ./...
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Added option to generate coverage details during unit tests
* GitHub workflow to use `make test-cover` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
