### PR TITLE
add replication group declarative tests, remove unused argument from engineVersionsDiffer

### DIFF
--- a/pkg/resource/replication_group/custom_update_api_test.go
+++ b/pkg/resource/replication_group/custom_update_api_test.go
@@ -966,9 +966,9 @@ func provideCacheClusterSecurityGroups(IDs ...string) []*svcsdk.SecurityGroupMem
 	return securityGroups
 }
 
-// TestEngineVersionDiffer tests scenarios to check if desired, latest (from cache cluster)
+// TestEngineVersionsDiffer tests scenarios to check if desired, latest (from cache cluster)
 // Engine Version configuration differs.
-func TestEngineVersionDiffer(t *testing.T) {
+func TestEngineVersionsDiffer(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	// setup
@@ -976,41 +976,37 @@ func TestEngineVersionDiffer(t *testing.T) {
 	// Tests
 	t.Run("NoDiff=NoSpec_NoStatus", func(t *testing.T) {
 		desiredRG := provideResource()
-		latestRG := provideResource()
 		latestCacheCluster := provideCacheCluster()
 		require.Nil(desiredRG.ko.Spec.SecurityGroupIDs)
 		require.Nil(latestCacheCluster.SecurityGroups)
-		differ := rm.engineVersionDiffer(desiredRG, latestRG, latestCacheCluster)
+		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
 		assert.False(differ)
 	})
 	t.Run("NoDiff=NoSpec_HasStatus", func(t *testing.T) {
 		desiredRG := provideResource()
-		latestRG := provideResource()
 		latestCacheCluster := provideCacheCluster()
 		latestEV := "test-engine-version"
 		latestCacheCluster.EngineVersion = &latestEV
 		require.Nil(desiredRG.ko.Spec.EngineVersion)
 		require.NotNil(latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionDiffer(desiredRG, latestRG, latestCacheCluster)
+		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
 		assert.False(differ)
 	})
 	t.Run("NoDiff=Spec_Status_Match", func(t *testing.T) {
 		desiredRG := provideResource()
 		latestEV := "test-engine-version"
 		desiredRG.ko.Spec.EngineVersion = &latestEV
-		latestRG := provideResource()
 		latestCacheCluster := provideCacheCluster()
 		latestCacheCluster.EngineVersion = &latestEV
 		require.NotNil(desiredRG.ko.Spec.EngineVersion)
 		require.NotNil(latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionDiffer(desiredRG, latestRG, latestCacheCluster)
+		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
 		assert.False(differ)
 	})
 	t.Run("Diff=Spec_Status_MisMatch", func(t *testing.T) {
 		desiredRG := provideResource()
 		desiredEV := "desired-test-engine-version"
 		desiredRG.ko.Spec.EngineVersion = &desiredEV
-		latestRG := provideResource()
 		latestCacheCluster := provideCacheCluster()
 		latestEV := "latest-test-engine-version"
 		latestCacheCluster.EngineVersion = &latestEV
@@ -1018,7 +1014,7 @@ func TestEngineVersionDiffer(t *testing.T) {
 		require.NotNil(desiredRG.ko.Spec.EngineVersion)
 		require.NotNil(latestCacheCluster.EngineVersion)
 		require.NotEqual(*desiredRG.ko.Spec.EngineVersion, *latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionDiffer(desiredRG, latestRG, latestCacheCluster)
+		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
 		assert.True(differ)
 	})
 }

--- a/pkg/resource/replication_group/testdata/cache_clusters/read_many/rg_cmd_primary_cache_node.json
+++ b/pkg/resource/replication_group/testdata/cache_clusters/read_many/rg_cmd_primary_cache_node.json
@@ -1,0 +1,32 @@
+{
+  "CacheClusters": [
+    {
+      "CacheClusterId": "rg-cmd-001",
+      "ReplicationGroupId": "rg-cmd",
+      "CacheClusterStatus": "available",
+      "SnapshotRetentionLimit": 0,
+      "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+      "CacheNodeType": "cache.t3.micro",
+      "TransitEncryptionEnabled": false,
+      "Engine": "redis",
+      "CacheSecurityGroups": [],
+      "NumCacheNodes": 1,
+      "AutoMinorVersionUpgrade": true,
+      "PendingModifiedValues": {},
+      "PreferredMaintenanceWindow": "wed:08:00-wed:09:00",
+      "CacheSubnetGroupName": "default",
+      "AuthTokenEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "EngineVersion": "5.0.0",
+      "CacheClusterCreateTime": "2021-04-13T19:07:04.983Z",
+      "PreferredAvailabilityZone": "us-east-1b",
+      "SnapshotWindow": "06:30-07:30",
+      "ARN": "arn:aws:elasticache:us-east-1:012345678910:cluster:rg-cmd-001",
+      "CacheParameterGroup": {
+        "CacheNodeIdsToReboot": [],
+        "CacheParameterGroupName": "default.redis5.0",
+        "ParameterApplyStatus": "in-sync"
+      }
+    }
+  ]
+}

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml
@@ -1,0 +1,94 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  engineVersion: 5.0.6 # new config has been applied; this is the new engine version but no action has been taken yet
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-04-13T19:07:05Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1b
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica.yaml
@@ -1,0 +1,99 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 2 # mismatch between this and member clusters because new config was just applied
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-03-30T20:12:00Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1b
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_desired.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_desired.yaml
@@ -1,0 +1,90 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.small
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.large
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-04-12T23:28:40Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1c
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_latest.yaml
@@ -1,0 +1,90 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.large
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-04-12T23:28:40Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1c
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
@@ -1,0 +1,56 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  engineVersion: 5.0.6
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "False"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-04-13T19:07:05Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1b
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: modifying
+  pendingModifiedValues: {}
+  status: modifying

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_increase_replica_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_increase_replica_initiated.yaml
@@ -1,0 +1,56 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 2
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "False"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-03-30T20:12:00Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+    - rg-cmd-003
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1b
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: modifying
+  pendingModifiedValues: {}
+  status: modifying

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
@@ -1,0 +1,55 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.small
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "False"
+      type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+    - date: "2021-04-12T23:28:40Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cmd-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-east-1d
+          readEndpoint:
+            address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+        - cacheClusterID: rg-cmd-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-east-1c
+          readEndpoint:
+            address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+            port: 6379
+      primaryEndpoint:
+        address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      readerEndpoint:
+        address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+        port: 6379
+      status: modifying
+  pendingModifiedValues: {}
+  status: modifying

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_before_create.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_before_create.yaml
@@ -1,0 +1,24 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  nodeGroupConfiguration:
+    - nodeGroupID: "1111"
+      primaryAvailabilityZone: us-east-1a
+      replicaAvailabilityZones:
+        - us-east-1b
+      replicaCount: 1
+      slots: 0-5999
+    - nodeGroupID: "2222"
+      primaryAvailabilityZone: us-east-1c
+      replicaAvailabilityZones:
+        - us-east-1d
+        - us-east-1a
+        - us-east-1b
+      replicaCount: 3
+      slots: 6000-16383
+  numNodeGroups: 2
+  replicationGroupDescription: cluster-mode enabled RG
+  replicationGroupID: rg-cme

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
@@ -1,0 +1,46 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  cacheSubnetGroupName: default
+  engine: redis
+  nodeGroupConfiguration:
+    - nodeGroupID: "1111"
+      primaryAvailabilityZone: us-east-1a
+      replicaAvailabilityZones:
+        - us-east-1b
+      replicaCount: 1
+      slots: 0-5999
+    - nodeGroupID: "2222"
+      primaryAvailabilityZone: us-east-1c
+      replicaAvailabilityZones:
+        - us-east-1d
+        - us-east-1a
+        - us-east-1b
+      replicaCount: 3
+      slots: 6000-16383
+  numNodeGroups: 2
+  replicationGroupDescription: cluster-mode enabled RG
+  replicationGroupID: rg-cme
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cme
+    ownerAccountID: ""
+  automaticFailover: enabled
+  clusterEnabled: true
+  conditions:
+    - status: "False"
+      type: ACK.ResourceSynced
+  description: cluster-mode enabled RG
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cme-1111-001
+    - rg-cme-1111-002
+    - rg-cme-2222-001
+    - rg-cme-2222-002
+    - rg-cme-2222-003
+    - rg-cme-2222-004
+  multiAZ: disabled
+  pendingModifiedValues: {}
+  status: creating

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_invalid_scale_out_attempted.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_invalid_scale_out_attempted.yaml
@@ -1,0 +1,117 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  cacheSubnetGroupName: default
+  engine: redis
+  nodeGroupConfiguration:
+    - nodeGroupID: "1111"
+      primaryAvailabilityZone: us-east-1a
+      replicaAvailabilityZones:
+        - us-east-1b
+      replicaCount: 1
+      slots: 0-5999
+    - nodeGroupID: "2222"
+      primaryAvailabilityZone: us-east-1c
+      replicaAvailabilityZones:
+        - us-east-1d
+        - us-east-1a
+        - us-east-1b
+      replicaCount: 3
+      slots: 6000-16383
+  numNodeGroups: 3 # this is the mismatch; 3 shards indicated but only 2 are specified in above nodeGroupConfiguration
+  replicationGroupDescription: cluster-mode enabled RG
+  replicationGroupID: rg-cme
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cme
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.large
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: enabled
+  clusterEnabled: true
+  conditions:
+    - status: "True" #TODO: should synced condition be set false when terminal condition is true?
+      type: ACK.ResourceSynced
+    - message: Configuration for all the node groups should be provided.
+      status: "True"
+      type: ACK.Terminal
+  configurationEndpoint:
+    address: rg-cme.xxxxxx.clustercfg.use1.cache.amazonaws.com
+    port: 6379
+  description: cluster-mode enabled RG
+  events:
+    - date: "2021-04-14T19:36:01Z"
+      message: Replication group rg-cme created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cme-1111-001
+    - rg-cme-1111-002
+    - rg-cme-2222-001
+    - rg-cme-2222-002
+    - rg-cme-2222-003
+    - rg-cme-2222-004
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "1111"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cme-1111-001
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1a
+        - cacheClusterID: rg-cme-1111-002
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1b
+      slots: 0-5999
+      status: available
+    - nodeGroupID: "2222"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cme-2222-001
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1c
+        - cacheClusterID: rg-cme-2222-002
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1d
+        - cacheClusterID: rg-cme-2222-003
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1a
+        - cacheClusterID: rg-cme-2222-004
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1b
+      slots: 6000-16383
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_shard_mismatch.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_shard_mismatch.yaml
@@ -1,0 +1,114 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  cacheNodeType: cache.t3.micro
+  cacheSubnetGroupName: default
+  engine: redis
+  nodeGroupConfiguration:
+    - nodeGroupID: "1111"
+      primaryAvailabilityZone: us-east-1a
+      replicaAvailabilityZones:
+        - us-east-1b
+      replicaCount: 1
+      slots: 0-5999
+    - nodeGroupID: "2222"
+      primaryAvailabilityZone: us-east-1c
+      replicaAvailabilityZones:
+        - us-east-1d
+        - us-east-1a
+        - us-east-1b
+      replicaCount: 3
+      slots: 6000-16383
+  numNodeGroups: 3 # this is the mismatch; 3 shards indicated but only 2 are specified in above nodeGroupConfiguration
+  replicationGroupDescription: cluster-mode enabled RG
+  replicationGroupID: rg-cme
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cme
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.large
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: enabled
+  clusterEnabled: true
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  configurationEndpoint:
+    address: rg-cme.xxxxxx.clustercfg.use1.cache.amazonaws.com
+    port: 6379
+  description: cluster-mode enabled RG
+  events:
+    - date: "2021-04-14T19:36:01Z"
+      message: Replication group rg-cme created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cme-1111-001
+    - rg-cme-1111-002
+    - rg-cme-2222-001
+    - rg-cme-2222-002
+    - rg-cme-2222-003
+    - rg-cme-2222-004
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "1111"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cme-1111-001
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1a
+        - cacheClusterID: rg-cme-1111-002
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1b
+      slots: 0-5999
+      status: available
+    - nodeGroupID: "2222"
+      nodeGroupMembers:
+        - cacheClusterID: rg-cme-2222-001
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1c
+        - cacheClusterID: rg-cme-2222-002
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1d
+        - cacheClusterID: rg-cme-2222-003
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1a
+        - cacheClusterID: rg-cme-2222-004
+          cacheNodeID: "0001"
+          preferredAvailabilityZone: us-east-1b
+      slots: 6000-16383
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/create/rg_cme_creating.json
+++ b/pkg/resource/replication_group/testdata/replication_group/create/rg_cme_creating.json
@@ -1,0 +1,26 @@
+{
+  "ReplicationGroup": {
+    "Status": "creating",
+    "MultiAZ": "disabled",
+    "Description": "cluster-mode enabled RG",
+    "AtRestEncryptionEnabled": false,
+    "ClusterEnabled": true,
+    "ReplicationGroupId": "rg-cme",
+    "GlobalReplicationGroupInfo": {},
+    "SnapshotRetentionLimit": 0,
+    "AutomaticFailover": "enabled",
+    "TransitEncryptionEnabled": false,
+    "SnapshotWindow": "08:00-09:00",
+    "MemberClusters": [
+      "rg-cme-1111-001",
+      "rg-cme-1111-002",
+      "rg-cme-2222-001",
+      "rg-cme-2222-002",
+      "rg-cme-2222-003",
+      "rg-cme-2222-004"
+    ],
+    "CacheNodeType": "cache.t3.micro",
+    "ARN": "arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cme",
+    "PendingModifiedValues": {}
+  }
+}

--- a/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_engine_upgrade_initiated.json
+++ b/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_engine_upgrade_initiated.json
@@ -1,0 +1,58 @@
+{
+  "ReplicationGroup": {
+    "Status": "modifying",
+    "MultiAZ": "disabled",
+    "Description": "cluster-mode disabled RG",
+    "NodeGroups": [
+      {
+        "Status": "modifying",
+        "NodeGroupMembers": [
+          {
+            "CurrentRole": "primary",
+            "PreferredAvailabilityZone": "us-east-1b",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-001"
+          },
+          {
+            "CurrentRole": "replica",
+            "PreferredAvailabilityZone": "us-east-1d",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-002"
+          }
+        ],
+        "ReaderEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        },
+        "NodeGroupId": "0001",
+        "PrimaryEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        }
+      }
+    ],
+    "AtRestEncryptionEnabled": false,
+    "ClusterEnabled": false,
+    "ReplicationGroupId": "rg-cmd",
+    "GlobalReplicationGroupInfo": {},
+    "SnapshotRetentionLimit": 0,
+    "AutomaticFailover": "disabled",
+    "TransitEncryptionEnabled": false,
+    "SnapshotWindow": "06:30-07:30",
+    "MemberClusters": [
+      "rg-cmd-001",
+      "rg-cmd-002"
+    ],
+    "CacheNodeType": "cache.t3.micro",
+    "ARN": "arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd",
+    "PendingModifiedValues": {}
+  }
+}

--- a/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_increase_replica_initiated.json
+++ b/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_increase_replica_initiated.json
@@ -1,0 +1,59 @@
+{
+  "ReplicationGroup": {
+    "Status": "modifying",
+    "MultiAZ": "disabled",
+    "Description": "cluster-mode disabled RG",
+    "NodeGroups": [
+      {
+        "Status": "modifying",
+        "NodeGroupMembers": [
+          {
+            "CurrentRole": "primary",
+            "PreferredAvailabilityZone": "us-east-1b",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-001"
+          },
+          {
+            "CurrentRole": "replica",
+            "PreferredAvailabilityZone": "us-east-1d",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-002"
+          }
+        ],
+        "ReaderEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        },
+        "NodeGroupId": "0001",
+        "PrimaryEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        }
+      }
+    ],
+    "AtRestEncryptionEnabled": false,
+    "ClusterEnabled": false,
+    "ReplicationGroupId": "rg-cmd",
+    "GlobalReplicationGroupInfo": {},
+    "SnapshotRetentionLimit": 0,
+    "AutomaticFailover": "disabled",
+    "TransitEncryptionEnabled": false,
+    "SnapshotWindow": "10:00-11:00",
+    "MemberClusters": [
+      "rg-cmd-001",
+      "rg-cmd-002",
+      "rg-cmd-003"
+    ],
+    "CacheNodeType": "cache.t3.micro",
+    "ARN": "arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd",
+    "PendingModifiedValues": {}
+  }
+}

--- a/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_scale_up_initiated.json
+++ b/pkg/resource/replication_group/testdata/replication_group/update/rg_cmd_scale_up_initiated.json
@@ -1,0 +1,58 @@
+{
+  "ReplicationGroup": {
+    "Status": "modifying",
+    "MultiAZ": "disabled",
+    "Description": "cluster-mode disabled RG",
+    "NodeGroups": [
+      {
+        "Status": "modifying",
+        "NodeGroupMembers": [
+          {
+            "CurrentRole": "primary",
+            "PreferredAvailabilityZone": "us-east-1d",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-001"
+          },
+          {
+            "CurrentRole": "replica",
+            "PreferredAvailabilityZone": "us-east-1c",
+            "CacheNodeId": "0001",
+            "ReadEndpoint": {
+              "Port": 6379,
+              "Address": "rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com"
+            },
+            "CacheClusterId": "rg-cmd-002"
+          }
+        ],
+        "ReaderEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        },
+        "NodeGroupId": "0001",
+        "PrimaryEndpoint": {
+          "Port": 6379,
+          "Address": "rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+        }
+      }
+    ],
+    "AtRestEncryptionEnabled": false,
+    "ClusterEnabled": false,
+    "ReplicationGroupId": "rg-cmd",
+    "GlobalReplicationGroupInfo": {},
+    "SnapshotRetentionLimit": 0,
+    "AutomaticFailover": "disabled",
+    "TransitEncryptionEnabled": false,
+    "SnapshotWindow": "09:00-10:00",
+    "MemberClusters": [
+      "rg-cmd-001",
+      "rg-cmd-002"
+    ],
+    "CacheNodeType": "cache.t3.micro",
+    "ARN": "arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd",
+    "PendingModifiedValues": {}
+  }
+}

--- a/pkg/resource/replication_group/testdata/test_suite.yaml
+++ b/pkg/resource/replication_group/testdata/test_suite.yaml
@@ -31,7 +31,6 @@ tests:
         description: "Create a new replication group; ensure ko.Status shows that this create has been initiated"
         given:
           desired_state: "replication_group/cr/rg_cmd_before_create.yaml"
-          latest_state: #TODO: remove once we have an update case that demonstrates the use of this
           svc_api:
             - operation: CreateReplicationGroupWithContext
               output_fixture: "replication_group/create/rg_cmd_creating.json"
@@ -58,7 +57,6 @@ tests:
         description: "Given desired state matches with server side resource data, ko.Status remain unchanged (resource is stable)"
         given: # fixture
           desired_state: "replication_group/cr/rg_cmd_create_completed.yaml"
-          latest_state: #TODO: remove once we have an update case that demonstrates the use of this
           svc_api:
             - operation: DescribeReplicationGroupsWithContext
               output_fixture: "replication_group/read_one/rg_cmd_create_completed.json"
@@ -69,6 +67,44 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml" #unchanged
+          error: nil
+      - name: "Update=IncreaseReplicaCount"
+        description: "Ensure a replica is added once a new config is provided"
+        given: # currently, desired and latest end up being the same in the reconciler (despite a newly applied config)
+          desired_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
+          svc_api:
+            - operation: IncreaseReplicaCountWithContext
+              output_fixture: "replication_group/update/rg_cmd_increase_replica_initiated.json"
+        invoke: Update
+        expect:
+          latest_state: "replication_group/cr/rg_cmd_increase_replica_initiated.yaml"
+          error: nil
+      - name: "Update=ScaleUp"
+        description: "Scale up replication group to larger instance type"
+        given:
+          desired_state: "replication_group/cr/rg_cmd_before_scale_up_desired.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_scale_up_latest.yaml"
+          svc_api:
+            - operation: ModifyReplicationGroupWithContext
+              output_fixture: "replication_group/update/rg_cmd_scale_up_initiated.json"
+        invoke: Update
+        expect:
+          latest_state: "replication_group/cr/rg_cmd_scale_up_initiated.yaml"
+          error: nil
+      - name: "Update=UpgradeEngine"
+        description: "Upgrade Redis engine version from 5.0.0 to a newer version"
+        given: # desired and latest same due to ReadOne behavior, same as increase replica count case
+          desired_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
+          svc_api:
+            - operation: ModifyReplicationGroupWithContext
+              output_fixture: "replication_group/update/rg_cmd_engine_upgrade_initiated.json"
+            - operation: DescribeCacheClustersWithContext
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
+        invoke: Update
+        expect:
+          latest_state: "replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml"
           error: nil
       - name: "Delete"
         description: "Delete cluster mode-disabled RG"
@@ -81,3 +117,31 @@ tests:
         expect: # for the delete case we don't expect a new latest state or a non-nil error
           latest_state: nil
           error: nil
+  - name: Cluster mode enabled replication group
+    description: Cluster mode enabled replication group CRUD tests
+    scenarios:
+      - name: "Create=CustomShardConfig"
+        description: Create CME RG with custom node group configuration
+        given:
+          desired_state: "replication_group/cr/rg_cme_before_create.yaml"
+          svc_api:
+            - operation: CreateReplicationGroupWithContext
+              output_fixture: "replication_group/create/rg_cme_creating.json"
+        invoke: Create
+        expect:
+          latest_state: "replication_group/cr/rg_cme_create_initiated.yaml"
+          error: nil
+      - name: "Update=ShardConfigMismatch"
+        description: Increasing NumNodeGroups without changing NodeGroupConfiguration should result in a terminal condition
+        given:
+          desired_state: "replication_group/cr/rg_cme_shard_mismatch.yaml"
+          latest_state: "replication_group/cr/rg_cme_shard_mismatch.yaml"
+          svc_api:
+            - operation: ModifyReplicationGroupShardConfigurationWithContext
+              error:
+                code: InvalidParameterValue
+                message: Configuration for all the node groups should be provided.
+        invoke: Update
+        expect:
+          latest_state: "replication_group/cr/rg_cme_invalid_scale_out_attempted.yaml"
+          error: resource is in terminal condition


### PR DESCRIPTION
Description of changes:

- increase replication group code coverage (probably best to focus review on `test_suite.yaml` since there are many `testdata` files)
- small tweak to engineVersionsDiffer: removed the second argument as it was unused

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
