### PR TITLE
modify customSetOutput to update latest.Spec fields where possible

### DIFF
--- a/pkg/resource/replication_group/manager_test.go
+++ b/pkg/resource/replication_group/manager_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 // TestReadOne_Exists runs resource manager ReadOne test scenario
-// TODO: Declarative Tests make this method redundant;remove this test when Declarative Test runner is checked in.
+// Declarative tests make this test redundant, but it remains to demonstrate the difference between a declarative
+// test (as specified in test_suite.yaml) and a traditional imperative test.
 func TestReadOne_Exists(t *testing.T) {
 	assert := assert.New(t)
 
@@ -51,6 +52,10 @@ func TestReadOne_Exists(t *testing.T) {
 	var mockDescribeEventsOutput svcsdk.DescribeEventsOutput
 	testutil.LoadFromFixture(filepath.Join("testdata", "events", "read_many", "rg_cmd_events.json"), &mockDescribeEventsOutput)
 	mocksdkapi.On("DescribeEventsWithContext", mock.Anything, mock.Anything).Return(&mockDescribeEventsOutput, nil)
+	// DescribeCacheClusters
+	var mockDescribeCacheClusterOutput svcsdk.DescribeCacheClustersOutput
+	testutil.LoadFromFixture(filepath.Join("testdata", "cache_clusters", "read_many", "rg_cmd_primary_cache_node.json"), &mockDescribeCacheClusterOutput)
+	mocksdkapi.On("DescribeCacheClusters", mock.Anything, mock.Anything).Return(&mockDescribeCacheClusterOutput, nil)
 
 	var delegate = testRunnerDelegate{t: t}
 

--- a/pkg/resource/replication_group/manager_test_suite_test.go
+++ b/pkg/resource/replication_group/manager_test_suite_test.go
@@ -79,6 +79,9 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	case "DescribeCacheClustersWithContext":
 		var output svcsdk.DescribeCacheClustersOutput
 		return &output, nil
+	case "DescribeCacheClusters":
+		var output svcsdk.DescribeCacheClustersOutput
+		return &output, nil
 	case "IncreaseReplicaCountWithContext":
 		var output svcsdk.IncreaseReplicaCountOutput
 		return &output, nil

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
@@ -4,29 +4,67 @@ kind: ReplicationGroup
 spec:
   cacheNodeType: cache.t3.micro
   engine: redis
+  engineVersion: 5.0.0 # this should still be the old engine version
   numNodeGroups: 1
-  replicasPerNodeGroup: 1 # increaseReplicaCount returns a nodeGroups list without the new replica, so this is still 1
+  replicasPerNodeGroup: 1
   replicationGroupDescription: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
     ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
   authTokenEnabled: false
   automaticFailover: disabled
   clusterEnabled: false
   conditions:
-    - status: "False"
+    - status: "True"
       type: ACK.ResourceSynced
   description: cluster-mode disabled RG
   events:
-    - date: "2021-03-30T20:12:00Z"
+    - date: "2021-04-13T19:07:05Z"
       message: Replication group rg-cmd created
   globalReplicationGroupInfo: {}
   memberClusters:
     - rg-cmd-001
     - rg-cmd-002
-    - rg-cmd-003
   multiAZ: disabled
   nodeGroups:
     - nodeGroupID: "0001"
@@ -51,6 +89,6 @@ status:
       readerEndpoint:
         address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
         port: 6379
-      status: modifying
+      status: available
   pendingModifiedValues: {}
-  status: modifying
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
@@ -5,18 +5,62 @@ spec:
   cacheNodeType: cache.t3.micro
   engine: redis
   numNodeGroups: 1
-  replicasPerNodeGroup: 1 # increaseReplicaCount returns a nodeGroups list without the new replica, so this is still 1
+  replicasPerNodeGroup: 1 # as this is the latest state, replicasPerNodeGroup should be consistent with memberClusters/nodeGroups
   replicationGroupDescription: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
     ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
   authTokenEnabled: false
   automaticFailover: disabled
   clusterEnabled: false
   conditions:
-    - status: "False"
+    - status: "True"
       type: ACK.ResourceSynced
   description: cluster-mode disabled RG
   events:
@@ -26,7 +70,6 @@ status:
   memberClusters:
     - rg-cmd-001
     - rg-cmd-002
-    - rg-cmd-003
   multiAZ: disabled
   nodeGroups:
     - nodeGroupID: "0001"
@@ -51,6 +94,6 @@ status:
       readerEndpoint:
         address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
         port: 6379
-      status: modifying
+      status: available
   pendingModifiedValues: {}
-  status: modifying
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
@@ -4,7 +4,7 @@ kind: ReplicationGroup
 spec:
   cacheNodeType: cache.t3.micro
   engine: redis
-  engineVersion: 5.0.6
+  engineVersion: 5.0.0 # expected latest should still have the old engine version as it hasn't been modified yet
   numNodeGroups: 1
   replicasPerNodeGroup: 1
   replicationGroupDescription: cluster-mode disabled RG

--- a/pkg/resource/replication_group/testdata/test_suite.yaml
+++ b/pkg/resource/replication_group/testdata/test_suite.yaml
@@ -49,6 +49,8 @@ tests:
               output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types.json"
             - operation: DescribeEventsWithContext
               output_fixture: "events/read_many/rg_cmd_events.json"
+            - operation: DescribeCacheClusters
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: ReadOne
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml"
@@ -64,18 +66,22 @@ tests:
               output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types.json"
             - operation: DescribeEventsWithContext
               output_fixture: "events/read_many/rg_cmd_events.json"
+            - operation: DescribeCacheClusters
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: ReadOne
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml" #unchanged
           error: nil
       - name: "Update=IncreaseReplicaCount"
         description: "Ensure a replica is added once a new config is provided"
-        given: # currently, desired and latest end up being the same in the reconciler (despite a newly applied config)
+        given:
           desired_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
-          latest_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_increase_replica_latest.yaml"
           svc_api:
             - operation: IncreaseReplicaCountWithContext
               output_fixture: "replication_group/update/rg_cmd_increase_replica_initiated.json"
+            - operation: DescribeCacheClusters
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: Update
         expect:
           latest_state: "replication_group/cr/rg_cmd_increase_replica_initiated.yaml"
@@ -88,6 +94,8 @@ tests:
           svc_api:
             - operation: ModifyReplicationGroupWithContext
               output_fixture: "replication_group/update/rg_cmd_scale_up_initiated.json"
+            - operation: DescribeCacheClusters
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: Update
         expect:
           latest_state: "replication_group/cr/rg_cmd_scale_up_initiated.yaml"
@@ -96,11 +104,11 @@ tests:
         description: "Upgrade Redis engine version from 5.0.0 to a newer version"
         given: # desired and latest same due to ReadOne behavior, same as increase replica count case
           desired_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
-          latest_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml"
           svc_api:
             - operation: ModifyReplicationGroupWithContext
               output_fixture: "replication_group/update/rg_cmd_engine_upgrade_initiated.json"
-            - operation: DescribeCacheClustersWithContext
+            - operation: DescribeCacheClusters
               output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: Update
         expect:

--- a/test/e2e/resources/replicationgroup_cmd_update.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_update.yaml
@@ -1,0 +1,13 @@
+# Basic CMD replication group for testing Update behavior
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  engineVersion: $ENGINE_VERSION
+  numNodeGroups: $NUM_NODE_GROUPS
+  replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: $RG_ID

--- a/test/e2e/resources/replicationgroup_input_coverage.yaml
+++ b/test/e2e/resources/replicationgroup_input_coverage.yaml
@@ -4,7 +4,6 @@ metadata:
   name: $RG_ID
 spec:
   atRestEncryptionEnabled: true
-  authToken: testplaintexttoken
   autoMinorVersionUpgrade: true
   automaticFailoverEnabled: true
   cacheNodeType: cache.t3.small

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -20,9 +20,10 @@ import logging
 from time import sleep
 
 from acktest.resources import random_suffix_name
-from acktest.k8s import resources as k8s
+from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_elasticache_resource
 from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e.util import retrieve_cache_cluster
 
 RESOURCE_PLURAL = "replicationgroups"
 DEFAULT_WAIT_SECS = 30
@@ -121,6 +122,26 @@ def rg_cmd_fromsnapshot(bootstrap_resources, make_rg_name, make_replication_grou
     sleep(DEFAULT_WAIT_SECS)
     rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"])
 
+@pytest.fixture(scope="module")
+def rg_cmd_update_input(make_rg_name):
+    return {
+        "RG_ID": make_rg_name("rg-cmd-update"),
+        "ENGINE_VERSION": "5.0.0",
+        "NUM_NODE_GROUPS": "1",
+        "REPLICAS_PER_NODE_GROUP": "1"
+    }
+
+@pytest.fixture(scope="module")
+def rg_cmd_update(rg_cmd_update_input, make_replication_group, rg_deletion_waiter):
+    input_dict = rg_cmd_update_input
+
+    (reference, resource) = make_replication_group("replicationgroup_cmd_update", input_dict, input_dict["RG_ID"])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"])
 
 @service_marker
 class TestReplicationGroup:
@@ -132,6 +153,52 @@ class TestReplicationGroup:
     def test_rg_cmd_fromsnapshot(self, rg_cmd_fromsnapshot):
         (reference, _) = rg_cmd_fromsnapshot
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+    # test update behavior of controller; this test can be changed to include multiple chained updates
+    def test_rg_cmd_update(self, rg_cmd_update_input, rg_cmd_update):
+        (reference, _) = rg_cmd_update
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assertions after initial creation
+        desired_node_groups = int(rg_cmd_update_input['NUM_NODE_GROUPS'])
+        desired_replica_count = int(rg_cmd_update_input['REPLICAS_PER_NODE_GROUP'])
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes
+        cc = retrieve_cache_cluster(rg_cmd_update_input['RG_ID'])
+        assert cc is not None
+        assert cc['EngineVersion'] == rg_cmd_update_input['ENGINE_VERSION']
+
+        # increase replica count, wait for resource to sync
+        desired_replica_count += 1
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        patch = {"spec": {"replicasPerNodeGroup": desired_replica_count}}
+        _ = k8s.patch_custom_resource(reference, patch)
+        sleep(DEFAULT_WAIT_SECS) # required as controller has likely not placed the resource in modifying
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assert new state after increasing replica count
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes
+
+        # upgrade engine version, wait for resource to sync
+        desired_engine_version = "5.0.6"
+        patch = {"spec": {"engineVersion": desired_engine_version}}
+        _ = k8s.patch_custom_resource(reference, patch)
+        sleep(DEFAULT_WAIT_SECS)
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assert new state after upgrading engine version
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert resource['spec']['engineVersion'] == desired_engine_version
+        cc = retrieve_cache_cluster(rg_cmd_update_input['RG_ID'])
+        assert cc is not None
+        assert cc['EngineVersion'] == desired_engine_version
 
     def test_rg_auth_token(self, rg_auth_token):
         (reference, _) = rg_auth_token

--- a/test/e2e/util.py
+++ b/test/e2e/util.py
@@ -83,3 +83,15 @@ def provide_node_group_configuration(size: int):
     for i in range(1, size+1):
         ngc.append({"nodeGroupID": str(i).rjust(4, '0')})
     return ngc
+
+# retrieve first cache cluster found from specified replication group
+def retrieve_cache_cluster(rg_id: str):
+    rg_response = ec.describe_replication_groups(ReplicationGroupId=rg_id)
+
+    rg = rg_response['ReplicationGroups'][0]
+    if len(rg['MemberClusters']) == 0:
+        logging.debug(f"No member clusters found for replication group {rg_id}")
+        return None
+
+    cc_response = ec.describe_cache_clusters(CacheClusterId=rg['MemberClusters'][0])
+    return cc_response['CacheClusters'][0]


### PR DESCRIPTION
Description of changes:
In many cases, `latest.Spec` doesn't reflect the latest observed state for fields that the Elasticache API does not directly return. For example, we have to count the replicas from the `NodeGroups` portion of the API response to update `latest.Spec.ReplicasPerNodeGroup`, and we have to make an `DescribeCacheClusters` API call to retrieve information like the engine version (another field in `latest.Spec`.

The point of this PR is to initiate the process of updating all `latest.Spec` fields via `customSetOutput` so that `latest.Spec` actually reflects the latest observed state of the resource, therefore allowing the resource manager's `Update` to be invoked when appropriate. This logic was previously (and for the most part, still is) handled within the replication group resource manager's `Update`.

Spec fields covered:
- `ReplicasPerNodeGroup`
- `EngineVersion`

Changes were tested via the `make test-cover` target, and via a new e2e test in `test_replicationgroup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
