### PR TITLE
Add the OLM config

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -1,0 +1,48 @@
+---
+annotations:
+  capabilityLevel: Basic Install
+  shortDescription: AWS ElastiCache controller is a service controller for managing ElastiCache resources
+    in Kubernetes
+displayName: AWS Controllers for Kubernetes - Amazon ElastiCache
+description: |-
+  Manage Amazon ElastiCache resources in AWS from within your Kubernetes
+  cluster.
+
+
+  **About Amazon ElastiCache**
+  
+
+  Amazon ElastiCache allows you to seamlessly set up, run, and scale popular
+  open-source compatible in-memory data stores in the cloud. Build
+  data-intensive apps or boost the performance of your existing databases by
+  retrieving data from high throughput and low latency in-memory data stores.
+  Amazon ElastiCache is a popular choice for real-time use cases like Caching,
+  Session Stores, Gaming, Geospatial Services, Real-Time Analytics, and Queuing.
+  
+  
+  Amazon ElastiCache offers fully managed Redis, voted the most loved database
+  by developers in the Stack Overflow 2020 Developer Survey, and Memcached for
+  your most demanding applications that require sub-millisecond response times.
+
+
+  **About the AWS Controllers for Kubernetes**
+
+
+  This controller is a component of the
+  [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
+  project. This project is currently in **developer preview**. 
+samples:
+- kind: CacheParameterGroup
+  spec: '{}'
+- kind: CacheSubnetGroup
+  spec: '{}'
+- kind: ReplicationGroup
+  spec: '{}'
+- kind: Snapshot
+  spec: '{}'
+maintainers:
+- name: "Your Team Name"
+  email: "your-team@example.com"
+links:
+- name: Amazon ElastiCache Developer Resources
+  url: "https://aws.amazon.com/elasticache/developer-resources/"


### PR DESCRIPTION
Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>

**Issue #, if available:**
Related to https://github.com/aws-controllers-k8s/community/issues/744

**Description of changes:**
This PR will add the configuration necessary for the `ack-generate olm` subcommand to render the appropriate Operator Lifecycle Manager ("OLM") bundle assets into the repository.

For reference, the PR merging the `olm` subcommand is here: https://github.com/aws-controllers-k8s/code-generator/commit/cb1d017ccc59feaa7ed247df502a2414f37344b2

This configuration informs `ack-generate` on exactly how to lay down a [ClusterServiceVersion](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md) "kustomize" base, which is then used by Operator SDK to generate a bundle to represent a particular version of the project in OLM

Things to note:

* I just grabbed service information and links from product pages, but those can be changed.
* The maintainer contact information is left with a placeholder and will need to be updated by controller maintainers to an appropriate value before this is put to use.
* The CRDs listed in the samples section were aligned to those found in `config/crd/bases`. As this changes, so do the samples.
* The CRDs listed in the samples section need spec definitions, but for the moment I've specified an empty spec. From an OpenShift Console perspective, this is provided to users as a "template" or "base" for them to reference when attempting to create an instance of the resource through the GUI.

Scripts have already been published to aws-controllers-k8s/community for automating the process of releasing and subsequently generating a bundle. These scripts leverage this configuration and expect them to exist in the controller repository for each service.

https://github.com/aws-controllers-k8s/community/blob/main/scripts/build-controller-release.sh#L182-L196

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-create-bundle.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-build-bundle-image.sh

https://github.com/aws-controllers-k8s/community/blob/main/scripts/olm-publish-bundle-image.sh

Assuming you have the aws-controllers-k8s/community repo locally available already, as well as your service controller repository, that process looks something like this for an imaginary "v11.0.0" version:

- Generate bundling assets

```shell
cd community # run all scripts from the 
export ACK_GENERATE_OLM=true
./scripts/build-controller-release.sh elasticache v11.0.0
```

- Create the bundle on disk

```shell
./scripts/olm-create-bundle.sh elasticache 11.0.0
```

- Publish the bundle to a registry 

```shell
export ADD_RH_CERTIFICATION_LABELS=true
export DOCKER_REPOSITORY=example.com/where/you/are/testing
./scripts/olm-publish-bundle-image.sh elasticache 11.0.0
```

Here's a quick glimpse as to how the ClusterServiceVersion that is generated from this olmconfig gets generated (I used https://operatorhub.io/preview to get this screenshot):

(note, technically it would render with an extra space between the paragraphs - I took the screenshot before I fixed the spacing issue).

![ack-elasticache-preview](https://user-images.githubusercontent.com/1837593/117217465-06da5080-adc7-11eb-877d-a30907645df8.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 👍 
