### PR TITLE
Regenerate code, add e2e test for failing scenario

### DIFF
--- a/apis/v1alpha1/cache_parameter_group.go
+++ b/apis/v1alpha1/cache_parameter_group.go
@@ -22,12 +22,22 @@ import (
 
 // CacheParameterGroupSpec defines the desired state of CacheParameterGroup
 type CacheParameterGroupSpec struct {
+	// The name of the cache parameter group family that the cache parameter group
+	// can be used with.
+	//
+	// Valid values are: memcached1.4 | memcached1.5 | memcached1.6 | redis2.6 |
+	// redis2.8 | redis3.2 | redis4.0 | redis5.0 | redis6.x |
 	// +kubebuilder:validation:Required
 	CacheParameterGroupFamily *string `json:"cacheParameterGroupFamily"`
+	// A user-specified name for the cache parameter group.
 	// +kubebuilder:validation:Required
 	CacheParameterGroupName *string `json:"cacheParameterGroupName"`
+	// A user-specified description for the cache parameter group.
 	// +kubebuilder:validation:Required
-	Description         *string               `json:"description"`
+	Description *string `json:"description"`
+	// An array of parameter names and values for the parameter update. You must
+	// supply at least one parameter name and value; subsequent arguments are optional.
+	// A maximum of 20 parameters may be modified per request.
 	ParameterNameValues []*ParameterNameValue `json:"parameterNameValues,omitempty"`
 }
 
@@ -42,9 +52,13 @@ type CacheParameterGroupStatus struct {
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
-	Events     []*Event                 `json:"events,omitempty"`
-	IsGlobal   *bool                    `json:"isGlobal,omitempty"`
-	Parameters []*Parameter             `json:"parameters,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	Events []*Event `json:"events,omitempty"`
+	// Indicates whether the parameter group is associated with a Global Datastore
+	IsGlobal *bool `json:"isGlobal,omitempty"`
+	// A list of Parameter instances.
+	Parameters []*Parameter `json:"parameters,omitempty"`
 }
 
 // CacheParameterGroup is the Schema for the CacheParameterGroups API

--- a/apis/v1alpha1/cache_subnet_group.go
+++ b/apis/v1alpha1/cache_subnet_group.go
@@ -22,10 +22,17 @@ import (
 
 // CacheSubnetGroupSpec defines the desired state of CacheSubnetGroup
 type CacheSubnetGroupSpec struct {
+	// A description for the cache subnet group.
 	// +kubebuilder:validation:Required
 	CacheSubnetGroupDescription *string `json:"cacheSubnetGroupDescription"`
+	// A name for the cache subnet group. This value is stored as a lowercase string.
+	//
+	// Constraints: Must contain no more than 255 alphanumeric characters or hyphens.
+	//
+	// Example: mysubnetgroup
 	// +kubebuilder:validation:Required
 	CacheSubnetGroupName *string `json:"cacheSubnetGroupName"`
+	// A list of VPC subnet IDs for the cache subnet group.
 	// +kubebuilder:validation:Required
 	SubnetIDs []*string `json:"subnetIDs"`
 }
@@ -41,9 +48,14 @@ type CacheSubnetGroupStatus struct {
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
-	Events     []*Event                 `json:"events,omitempty"`
-	Subnets    []*Subnet                `json:"subnets,omitempty"`
-	VPCID      *string                  `json:"vpcID,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	Events []*Event `json:"events,omitempty"`
+	// A list of subnets associated with the cache subnet group.
+	Subnets []*Subnet `json:"subnets,omitempty"`
+	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
+	// group.
+	VPCID *string `json:"vpcID,omitempty"`
 }
 
 // CacheSubnetGroup is the Schema for the CacheSubnetGroups API

--- a/apis/v1alpha1/replication_group.go
+++ b/apis/v1alpha1/replication_group.go
@@ -22,39 +22,296 @@ import (
 
 // ReplicationGroupSpec defines the desired state of ReplicationGroup
 type ReplicationGroupSpec struct {
-	AtRestEncryptionEnabled    *bool                           `json:"atRestEncryptionEnabled,omitempty"`
-	AuthToken                  *ackv1alpha1.SecretKeyReference `json:"authToken,omitempty"`
-	AutoMinorVersionUpgrade    *bool                           `json:"autoMinorVersionUpgrade,omitempty"`
-	AutomaticFailoverEnabled   *bool                           `json:"automaticFailoverEnabled,omitempty"`
-	CacheNodeType              *string                         `json:"cacheNodeType,omitempty"`
-	CacheParameterGroupName    *string                         `json:"cacheParameterGroupName,omitempty"`
-	CacheSecurityGroupNames    []*string                       `json:"cacheSecurityGroupNames,omitempty"`
-	CacheSubnetGroupName       *string                         `json:"cacheSubnetGroupName,omitempty"`
-	Engine                     *string                         `json:"engine,omitempty"`
-	EngineVersion              *string                         `json:"engineVersion,omitempty"`
-	KMSKeyID                   *string                         `json:"kmsKeyID,omitempty"`
-	MultiAZEnabled             *bool                           `json:"multiAZEnabled,omitempty"`
-	NodeGroupConfiguration     []*NodeGroupConfiguration       `json:"nodeGroupConfiguration,omitempty"`
-	NotificationTopicARN       *string                         `json:"notificationTopicARN,omitempty"`
-	NumCacheClusters           *int64                          `json:"numCacheClusters,omitempty"`
-	NumNodeGroups              *int64                          `json:"numNodeGroups,omitempty"`
-	Port                       *int64                          `json:"port,omitempty"`
-	PreferredCacheClusterAZs   []*string                       `json:"preferredCacheClusterAZs,omitempty"`
-	PreferredMaintenanceWindow *string                         `json:"preferredMaintenanceWindow,omitempty"`
-	PrimaryClusterID           *string                         `json:"primaryClusterID,omitempty"`
-	ReplicasPerNodeGroup       *int64                          `json:"replicasPerNodeGroup,omitempty"`
+	// A flag that enables encryption at rest when set to true.
+	//
+	// You cannot modify the value of AtRestEncryptionEnabled after the replication
+	// group is created. To enable encryption at rest on a replication group you
+	// must set AtRestEncryptionEnabled to true when you create the replication
+	// group.
+	//
+	// Required: Only available when creating a replication group in an Amazon VPC
+	// using redis version 3.2.6, 4.x or later.
+	//
+	// Default: false
+	AtRestEncryptionEnabled *bool `json:"atRestEncryptionEnabled,omitempty"`
+	// Reserved parameter. The password used to access a password protected server.
+	//
+	// AuthToken can be specified only on replication groups where TransitEncryptionEnabled
+	// is true.
+	//
+	// For HIPAA compliance, you must specify TransitEncryptionEnabled as true,
+	// an AuthToken, and a CacheSubnetGroup.
+	//
+	// Password constraints:
+	//
+	//    * Must be only printable ASCII characters.
+	//
+	//    * Must be at least 16 characters and no more than 128 characters in length.
+	//
+	//    * The only permitted printable special characters are !, &, #, $, ^, <,
+	//    >, and -. Other printable special characters cannot be used in the AUTH
+	//    token.
+	//
+	// For more information, see AUTH password (http://redis.io/commands/AUTH) at
+	// http://redis.io/commands/AUTH.
+	AuthToken *ackv1alpha1.SecretKeyReference `json:"authToken,omitempty"`
+	// This parameter is currently disabled.
+	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
+	// Specifies whether a read-only replica is automatically promoted to read/write
+	// primary if the existing primary fails.
+	//
+	// AutomaticFailoverEnabled must be enabled for Redis (cluster mode enabled)
+	// replication groups.
+	//
+	// Default: false
+	AutomaticFailoverEnabled *bool `json:"automaticFailoverEnabled,omitempty"`
+	// The compute and memory capacity of the nodes in the node group (shard).
+	//
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
+	//
+	//    * General purpose: Current generation: M6g node types (available only
+	//    for Redis engine version 5.0.6 onward and for Memcached engine version
+	//    1.5.16 onward). cache.m6g.large, cache.m6g.xlarge, cache.m6g.2xlarge,
+	//    cache.m6g.4xlarge, cache.m6g.8xlarge, cache.m6g.12xlarge, cache.m6g.16xlarge
+	//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+	//    M5 node types: cache.m5.large, cache.m5.xlarge, cache.m5.2xlarge, cache.m5.4xlarge,
+	//    cache.m5.12xlarge, cache.m5.24xlarge M4 node types: cache.m4.large, cache.m4.xlarge,
+	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge T3 node types: cache.t3.micro,
+	//    cache.t3.small, cache.t3.medium T2 node types: cache.t2.micro, cache.t2.small,
+	//    cache.t2.medium Previous generation: (not recommended) T1 node types:
+	//    cache.t1.micro M1 node types: cache.m1.small, cache.m1.medium, cache.m1.large,
+	//    cache.m1.xlarge M3 node types: cache.m3.medium, cache.m3.large, cache.m3.xlarge,
+	//    cache.m3.2xlarge
+	//
+	//    * Compute optimized: Previous generation: (not recommended) C1 node types:
+	//    cache.c1.xlarge
+	//
+	//    * Memory optimized: Current generation: R6g node types (available only
+	//    for Redis engine version 5.0.6 onward and for Memcached engine version
+	//    1.5.16 onward). cache.r6g.large, cache.r6g.xlarge, cache.r6g.2xlarge,
+	//    cache.r6g.4xlarge, cache.r6g.8xlarge, cache.r6g.12xlarge, cache.r6g.16xlarge
+	//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+	//    R5 node types: cache.r5.large, cache.r5.xlarge, cache.r5.2xlarge, cache.r5.4xlarge,
+	//    cache.r5.12xlarge, cache.r5.24xlarge R4 node types: cache.r4.large, cache.r4.xlarge,
+	//    cache.r4.2xlarge, cache.r4.4xlarge, cache.r4.8xlarge, cache.r4.16xlarge
+	//    Previous generation: (not recommended) M2 node types: cache.m2.xlarge,
+	//    cache.m2.2xlarge, cache.m2.4xlarge R3 node types: cache.r3.large, cache.r3.xlarge,
+	//    cache.r3.2xlarge, cache.r3.4xlarge, cache.r3.8xlarge
+	//
+	// Additional node type info
+	//
+	//    * All current generation instance types are created in Amazon VPC by default.
+	//
+	//    * Redis append-only files (AOF) are not supported for T1 or T2 instances.
+	//
+	//    * Redis Multi-AZ with automatic failover is not supported on T1 instances.
+	//
+	//    * Redis configuration variables appendonly and appendfsync are not supported
+	//    on Redis version 2.8.22 and later.
+	CacheNodeType *string `json:"cacheNodeType,omitempty"`
+	// The name of the parameter group to associate with this replication group.
+	// If this argument is omitted, the default cache parameter group for the specified
+	// engine is used.
+	//
+	// If you are running Redis version 3.2.4 or later, only one node group (shard),
+	// and want to use a default parameter group, we recommend that you specify
+	// the parameter group by name.
+	//
+	//    * To create a Redis (cluster mode disabled) replication group, use CacheParameterGroupName=default.redis3.2.
+	//
+	//    * To create a Redis (cluster mode enabled) replication group, use CacheParameterGroupName=default.redis3.2.cluster.on.
+	CacheParameterGroupName *string `json:"cacheParameterGroupName,omitempty"`
+	// A list of cache security group names to associate with this replication group.
+	CacheSecurityGroupNames []*string `json:"cacheSecurityGroupNames,omitempty"`
+	// The name of the cache subnet group to be used for the replication group.
+	//
+	// If you're going to launch your cluster in an Amazon VPC, you need to create
+	// a subnet group before you start creating a cluster. For more information,
+	// see Subnets and Subnet Groups (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html).
+	CacheSubnetGroupName *string `json:"cacheSubnetGroupName,omitempty"`
+	// The name of the cache engine to be used for the clusters in this replication
+	// group.
+	Engine *string `json:"engine,omitempty"`
+	// The version number of the cache engine to be used for the clusters in this
+	// replication group. To view the supported cache engine versions, use the DescribeCacheEngineVersions
+	// operation.
+	//
+	// Important: You can upgrade to a newer engine version (see Selecting a Cache
+	// Engine and Version (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SelectEngine.html#VersionManagement))
+	// in the ElastiCache User Guide, but you cannot downgrade to an earlier engine
+	// version. If you want to use an earlier engine version, you must delete the
+	// existing cluster or replication group and create it anew with the earlier
+	// engine version.
+	EngineVersion *string `json:"engineVersion,omitempty"`
+	// The ID of the KMS key used to encrypt the disk in the cluster.
+	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	// A flag indicating if you have Multi-AZ enabled to enhance fault tolerance.
+	// For more information, see Minimizing Downtime: Multi-AZ (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html).
+	MultiAZEnabled *bool `json:"multiAZEnabled,omitempty"`
+	// A list of node group (shard) configuration options. Each node group (shard)
+	// configuration has the following members: PrimaryAvailabilityZone, ReplicaAvailabilityZones,
+	// ReplicaCount, and Slots.
+	//
+	// If you're creating a Redis (cluster mode disabled) or a Redis (cluster mode
+	// enabled) replication group, you can use this parameter to individually configure
+	// each node group (shard), or you can omit this parameter. However, it is required
+	// when seeding a Redis (cluster mode enabled) cluster from a S3 rdb file. You
+	// must configure each node group (shard) using this parameter because you must
+	// specify the slots for each node group.
+	NodeGroupConfiguration []*NodeGroupConfiguration `json:"nodeGroupConfiguration,omitempty"`
+	// The Amazon Resource Name (ARN) of the Amazon Simple Notification Service
+	// (SNS) topic to which notifications are sent.
+	//
+	// The Amazon SNS topic owner must be the same as the cluster owner.
+	NotificationTopicARN *string `json:"notificationTopicARN,omitempty"`
+	// The number of clusters this replication group initially has.
+	//
+	// This parameter is not used if there is more than one node group (shard).
+	// You should use ReplicasPerNodeGroup instead.
+	//
+	// If AutomaticFailoverEnabled is true, the value of this parameter must be
+	// at least 2. If AutomaticFailoverEnabled is false you can omit this parameter
+	// (it will default to 1), or you can explicitly set it to a value between 2
+	// and 6.
+	//
+	// The maximum permitted value for NumCacheClusters is 6 (1 primary plus 5 replicas).
+	NumCacheClusters *int64 `json:"numCacheClusters,omitempty"`
+	// An optional parameter that specifies the number of node groups (shards) for
+	// this Redis (cluster mode enabled) replication group. For Redis (cluster mode
+	// disabled) either omit this parameter or set it to 1.
+	//
+	// Default: 1
+	NumNodeGroups *int64 `json:"numNodeGroups,omitempty"`
+	// The port number on which each member of the replication group accepts connections.
+	Port *int64 `json:"port,omitempty"`
+	// A list of EC2 Availability Zones in which the replication group's clusters
+	// are created. The order of the Availability Zones in the list is the order
+	// in which clusters are allocated. The primary cluster is created in the first
+	// AZ in the list.
+	//
+	// This parameter is not used if there is more than one node group (shard).
+	// You should use NodeGroupConfiguration instead.
+	//
+	// If you are creating your replication group in an Amazon VPC (recommended),
+	// you can only locate clusters in Availability Zones associated with the subnets
+	// in the selected subnet group.
+	//
+	// The number of Availability Zones listed must equal the value of NumCacheClusters.
+	//
+	// Default: system chosen Availability Zones.
+	PreferredCacheClusterAZs []*string `json:"preferredCacheClusterAZs,omitempty"`
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period. Valid
+	// values for ddd are:
+	//
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
+	//
+	//    * sun
+	//
+	//    * mon
+	//
+	//    * tue
+	//
+	//    * wed
+	//
+	//    * thu
+	//
+	//    * fri
+	//
+	//    * sat
+	//
+	// Example: sun:23:00-mon:01:30
+	PreferredMaintenanceWindow *string `json:"preferredMaintenanceWindow,omitempty"`
+	// The identifier of the cluster that serves as the primary for this replication
+	// group. This cluster must already exist and have a status of available.
+	//
+	// This parameter is not required if NumCacheClusters, NumNodeGroups, or ReplicasPerNodeGroup
+	// is specified.
+	PrimaryClusterID *string `json:"primaryClusterID,omitempty"`
+	// An optional parameter that specifies the number of replica nodes in each
+	// node group (shard). Valid values are 0 to 5.
+	ReplicasPerNodeGroup *int64 `json:"replicasPerNodeGroup,omitempty"`
+	// A user-created description for the replication group.
 	// +kubebuilder:validation:Required
 	ReplicationGroupDescription *string `json:"replicationGroupDescription"`
+	// The replication group identifier. This parameter is stored as a lowercase
+	// string.
+	//
+	// Constraints:
+	//
+	//    * A name must contain from 1 to 40 alphanumeric characters or hyphens.
+	//
+	//    * The first character must be a letter.
+	//
+	//    * A name cannot end with a hyphen or contain two consecutive hyphens.
 	// +kubebuilder:validation:Required
-	ReplicationGroupID       *string   `json:"replicationGroupID"`
-	SecurityGroupIDs         []*string `json:"securityGroupIDs,omitempty"`
-	SnapshotARNs             []*string `json:"snapshotARNs,omitempty"`
-	SnapshotName             *string   `json:"snapshotName,omitempty"`
-	SnapshotRetentionLimit   *int64    `json:"snapshotRetentionLimit,omitempty"`
-	SnapshotWindow           *string   `json:"snapshotWindow,omitempty"`
-	Tags                     []*Tag    `json:"tags,omitempty"`
-	TransitEncryptionEnabled *bool     `json:"transitEncryptionEnabled,omitempty"`
-	UserGroupIDs             []*string `json:"userGroupIDs,omitempty"`
+	ReplicationGroupID *string `json:"replicationGroupID"`
+	// One or more Amazon VPC security groups associated with this replication group.
+	//
+	// Use this parameter only when you are creating a replication group in an Amazon
+	// Virtual Private Cloud (Amazon VPC).
+	SecurityGroupIDs []*string `json:"securityGroupIDs,omitempty"`
+	// A list of Amazon Resource Names (ARN) that uniquely identify the Redis RDB
+	// snapshot files stored in Amazon S3. The snapshot files are used to populate
+	// the new replication group. The Amazon S3 object name in the ARN cannot contain
+	// any commas. The new replication group will have the number of node groups
+	// (console: shards) specified by the parameter NumNodeGroups or the number
+	// of node groups configured by NodeGroupConfiguration regardless of the number
+	// of ARNs specified here.
+	//
+	// Example of an Amazon S3 ARN: arn:aws:s3:::my_bucket/snapshot1.rdb
+	SnapshotARNs []*string `json:"snapshotARNs,omitempty"`
+	// The name of a snapshot from which to restore data into the new replication
+	// group. The snapshot status changes to restoring while the new replication
+	// group is being created.
+	SnapshotName *string `json:"snapshotName,omitempty"`
+	// The number of days for which ElastiCache retains automatic snapshots before
+	// deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot
+	// that was taken today is retained for 5 days before being deleted.
+	//
+	// Default: 0 (i.e., automatic backups are disabled for this cluster).
+	SnapshotRetentionLimit *int64 `json:"snapshotRetentionLimit,omitempty"`
+	// The daily time range (in UTC) during which ElastiCache begins taking a daily
+	// snapshot of your node group (shard).
+	//
+	// Example: 05:00-09:00
+	//
+	// If you do not specify this parameter, ElastiCache automatically chooses an
+	// appropriate time range.
+	SnapshotWindow *string `json:"snapshotWindow,omitempty"`
+	// A list of cost allocation tags to be added to this resource. Tags are comma-separated
+	// key,value pairs (e.g. Key=myKey, Value=myKeyValue. You can include multiple
+	// tags as shown following: Key=myKey, Value=myKeyValue Key=mySecondKey, Value=mySecondKeyValue.
+	Tags []*Tag `json:"tags,omitempty"`
+	// A flag that enables in-transit encryption when set to true.
+	//
+	// You cannot modify the value of TransitEncryptionEnabled after the cluster
+	// is created. To enable in-transit encryption on a cluster you must set TransitEncryptionEnabled
+	// to true when you create a cluster.
+	//
+	// This parameter is valid only if the Engine parameter is redis, the EngineVersion
+	// parameter is 3.2.6, 4.x or later, and the cluster is being created in an
+	// Amazon VPC.
+	//
+	// If you enable in-transit encryption, you must also specify a value for CacheSubnetGroup.
+	//
+	// Required: Only available when creating a replication group in an Amazon VPC
+	// using redis version 3.2.6, 4.x or later.
+	//
+	// Default: false
+	//
+	// For HIPAA compliance, you must specify TransitEncryptionEnabled as true,
+	// an AuthToken, and a CacheSubnetGroup.
+	TransitEncryptionEnabled *bool `json:"transitEncryptionEnabled,omitempty"`
+	// The list of user groups to associate with the replication group.
+	UserGroupIDs []*string `json:"userGroupIDs,omitempty"`
 }
 
 // ReplicationGroupStatus defines the observed state of ReplicationGroup
@@ -67,24 +324,65 @@ type ReplicationGroupStatus struct {
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
-	Conditions                    []*ackv1alpha1.Condition               `json:"conditions"`
-	AllowedScaleDownModifications []*string                              `json:"allowedScaleDownModifications,omitempty"`
-	AllowedScaleUpModifications   []*string                              `json:"allowedScaleUpModifications,omitempty"`
-	AuthTokenEnabled              *bool                                  `json:"authTokenEnabled,omitempty"`
-	AuthTokenLastModifiedDate     *metav1.Time                           `json:"authTokenLastModifiedDate,omitempty"`
-	AutomaticFailover             *string                                `json:"automaticFailover,omitempty"`
-	ClusterEnabled                *bool                                  `json:"clusterEnabled,omitempty"`
-	ConfigurationEndpoint         *Endpoint                              `json:"configurationEndpoint,omitempty"`
-	Description                   *string                                `json:"description,omitempty"`
-	Events                        []*Event                               `json:"events,omitempty"`
-	GlobalReplicationGroupInfo    *GlobalReplicationGroupInfo            `json:"globalReplicationGroupInfo,omitempty"`
-	MemberClusters                []*string                              `json:"memberClusters,omitempty"`
-	MemberClustersOutpostARNs     []*string                              `json:"memberClustersOutpostARNs,omitempty"`
-	MultiAZ                       *string                                `json:"multiAZ,omitempty"`
-	NodeGroups                    []*NodeGroup                           `json:"nodeGroups,omitempty"`
-	PendingModifiedValues         *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
-	SnapshottingClusterID         *string                                `json:"snapshottingClusterID,omitempty"`
-	Status                        *string                                `json:"status,omitempty"`
+	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	// A string list, each element of which specifies a cache node type which you
+	// can use to scale your cluster or replication group. When scaling down a Redis
+	// cluster or replication group using ModifyCacheCluster or ModifyReplicationGroup,
+	// use a value from this list for the CacheNodeType parameter.
+	AllowedScaleDownModifications []*string `json:"allowedScaleDownModifications,omitempty"`
+	// A string list, each element of which specifies a cache node type which you
+	// can use to scale your cluster or replication group.
+	//
+	// When scaling up a Redis cluster or replication group using ModifyCacheCluster
+	// or ModifyReplicationGroup, use a value from this list for the CacheNodeType
+	// parameter.
+	AllowedScaleUpModifications []*string `json:"allowedScaleUpModifications,omitempty"`
+	// A flag that enables using an AuthToken (password) when issuing Redis commands.
+	//
+	// Default: false
+	AuthTokenEnabled *bool `json:"authTokenEnabled,omitempty"`
+	// The date the auth token was last modified
+	AuthTokenLastModifiedDate *metav1.Time `json:"authTokenLastModifiedDate,omitempty"`
+	// Indicates the status of automatic failover for this Redis replication group.
+	AutomaticFailover *string `json:"automaticFailover,omitempty"`
+	// A flag indicating whether or not this replication group is cluster enabled;
+	// i.e., whether its data can be partitioned across multiple shards (API/CLI:
+	// node groups).
+	//
+	// Valid values: true | false
+	ClusterEnabled *bool `json:"clusterEnabled,omitempty"`
+	// The configuration endpoint for this replication group. Use the configuration
+	// endpoint to connect to this replication group.
+	ConfigurationEndpoint *Endpoint `json:"configurationEndpoint,omitempty"`
+	// The user supplied description of the replication group.
+	Description *string `json:"description,omitempty"`
+	// A list of events. Each element in the list contains detailed information
+	// about one event.
+	Events []*Event `json:"events,omitempty"`
+	// The name of the Global Datastore and role of this replication group in the
+	// Global Datastore.
+	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo `json:"globalReplicationGroupInfo,omitempty"`
+	// The names of all the cache clusters that are part of this replication group.
+	MemberClusters []*string `json:"memberClusters,omitempty"`
+	// The outpost ARNs of the replication group's member clusters.
+	MemberClustersOutpostARNs []*string `json:"memberClustersOutpostARNs,omitempty"`
+	// A flag indicating if you have Multi-AZ enabled to enhance fault tolerance.
+	// For more information, see Minimizing Downtime: Multi-AZ (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html)
+	MultiAZ *string `json:"multiAZ,omitempty"`
+	// A list of node groups in this replication group. For Redis (cluster mode
+	// disabled) replication groups, this is a single-element list. For Redis (cluster
+	// mode enabled) replication groups, the list contains an entry for each node
+	// group (shard).
+	NodeGroups []*NodeGroup `json:"nodeGroups,omitempty"`
+	// A group of settings to be applied to the replication group, either immediately
+	// or during the next maintenance window.
+	PendingModifiedValues *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
+	// The cluster ID that is used as the daily snapshot source for the replication
+	// group.
+	SnapshottingClusterID *string `json:"snapshottingClusterID,omitempty"`
+	// The current state of this replication group - creating, available, modifying,
+	// deleting, create-failed, snapshotting.
+	Status *string `json:"status,omitempty"`
 }
 
 // ReplicationGroup is the Schema for the ReplicationGroups API

--- a/apis/v1alpha1/snapshot.go
+++ b/apis/v1alpha1/snapshot.go
@@ -22,11 +22,18 @@ import (
 
 // SnapshotSpec defines the desired state of Snapshot
 type SnapshotSpec struct {
-	CacheClusterID     *string `json:"cacheClusterID,omitempty"`
-	KMSKeyID           *string `json:"kmsKeyID,omitempty"`
+	// The identifier of an existing cluster. The snapshot is created from this
+	// cluster.
+	CacheClusterID *string `json:"cacheClusterID,omitempty"`
+	// The ID of the KMS key used to encrypt the snapshot.
+	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	// The identifier of an existing replication group. The snapshot is created
+	// from this replication group.
 	ReplicationGroupID *string `json:"replicationGroupID,omitempty"`
+	// A name for the snapshot being created.
 	// +kubebuilder:validation:Required
-	SnapshotName       *string `json:"snapshotName"`
+	SnapshotName *string `json:"snapshotName"`
+	// The name of an existing snapshot from which to make a copy.
 	SourceSnapshotName *string `json:"sourceSnapshotName,omitempty"`
 }
 
@@ -40,29 +47,135 @@ type SnapshotStatus struct {
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
-	Conditions                  []*ackv1alpha1.Condition `json:"conditions"`
-	AutoMinorVersionUpgrade     *bool                    `json:"autoMinorVersionUpgrade,omitempty"`
-	AutomaticFailover           *string                  `json:"automaticFailover,omitempty"`
-	CacheClusterCreateTime      *metav1.Time             `json:"cacheClusterCreateTime,omitempty"`
-	CacheNodeType               *string                  `json:"cacheNodeType,omitempty"`
-	CacheParameterGroupName     *string                  `json:"cacheParameterGroupName,omitempty"`
-	CacheSubnetGroupName        *string                  `json:"cacheSubnetGroupName,omitempty"`
-	Engine                      *string                  `json:"engine,omitempty"`
-	EngineVersion               *string                  `json:"engineVersion,omitempty"`
-	NodeSnapshots               []*NodeSnapshot          `json:"nodeSnapshots,omitempty"`
-	NumCacheNodes               *int64                   `json:"numCacheNodes,omitempty"`
-	NumNodeGroups               *int64                   `json:"numNodeGroups,omitempty"`
-	Port                        *int64                   `json:"port,omitempty"`
-	PreferredAvailabilityZone   *string                  `json:"preferredAvailabilityZone,omitempty"`
-	PreferredMaintenanceWindow  *string                  `json:"preferredMaintenanceWindow,omitempty"`
-	PreferredOutpostARN         *string                  `json:"preferredOutpostARN,omitempty"`
-	ReplicationGroupDescription *string                  `json:"replicationGroupDescription,omitempty"`
-	SnapshotRetentionLimit      *int64                   `json:"snapshotRetentionLimit,omitempty"`
-	SnapshotSource              *string                  `json:"snapshotSource,omitempty"`
-	SnapshotStatus              *string                  `json:"snapshotStatus,omitempty"`
-	SnapshotWindow              *string                  `json:"snapshotWindow,omitempty"`
-	TopicARN                    *string                  `json:"topicARN,omitempty"`
-	VPCID                       *string                  `json:"vpcID,omitempty"`
+	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	// This parameter is currently disabled.
+	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
+	// Indicates the status of automatic failover for the source Redis replication
+	// group.
+	AutomaticFailover *string `json:"automaticFailover,omitempty"`
+	// The date and time when the source cluster was created.
+	CacheClusterCreateTime *metav1.Time `json:"cacheClusterCreateTime,omitempty"`
+	// The name of the compute and memory capacity node type for the source cluster.
+	//
+	// The following node types are supported by ElastiCache. Generally speaking,
+	// the current generation types provide more memory and computational power
+	// at lower cost when compared to their equivalent previous generation counterparts.
+	//
+	//    * General purpose: Current generation: M6g node types (available only
+	//    for Redis engine version 5.0.6 onward and for Memcached engine version
+	//    1.5.16 onward). cache.m6g.large, cache.m6g.xlarge, cache.m6g.2xlarge,
+	//    cache.m6g.4xlarge, cache.m6g.8xlarge, cache.m6g.12xlarge, cache.m6g.16xlarge
+	//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+	//    M5 node types: cache.m5.large, cache.m5.xlarge, cache.m5.2xlarge, cache.m5.4xlarge,
+	//    cache.m5.12xlarge, cache.m5.24xlarge M4 node types: cache.m4.large, cache.m4.xlarge,
+	//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge T3 node types: cache.t3.micro,
+	//    cache.t3.small, cache.t3.medium T2 node types: cache.t2.micro, cache.t2.small,
+	//    cache.t2.medium Previous generation: (not recommended) T1 node types:
+	//    cache.t1.micro M1 node types: cache.m1.small, cache.m1.medium, cache.m1.large,
+	//    cache.m1.xlarge M3 node types: cache.m3.medium, cache.m3.large, cache.m3.xlarge,
+	//    cache.m3.2xlarge
+	//
+	//    * Compute optimized: Previous generation: (not recommended) C1 node types:
+	//    cache.c1.xlarge
+	//
+	//    * Memory optimized: Current generation: R6g node types (available only
+	//    for Redis engine version 5.0.6 onward and for Memcached engine version
+	//    1.5.16 onward). cache.r6g.large, cache.r6g.xlarge, cache.r6g.2xlarge,
+	//    cache.r6g.4xlarge, cache.r6g.8xlarge, cache.r6g.12xlarge, cache.r6g.16xlarge
+	//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+	//    R5 node types: cache.r5.large, cache.r5.xlarge, cache.r5.2xlarge, cache.r5.4xlarge,
+	//    cache.r5.12xlarge, cache.r5.24xlarge R4 node types: cache.r4.large, cache.r4.xlarge,
+	//    cache.r4.2xlarge, cache.r4.4xlarge, cache.r4.8xlarge, cache.r4.16xlarge
+	//    Previous generation: (not recommended) M2 node types: cache.m2.xlarge,
+	//    cache.m2.2xlarge, cache.m2.4xlarge R3 node types: cache.r3.large, cache.r3.xlarge,
+	//    cache.r3.2xlarge, cache.r3.4xlarge, cache.r3.8xlarge
+	//
+	// Additional node type info
+	//
+	//    * All current generation instance types are created in Amazon VPC by default.
+	//
+	//    * Redis append-only files (AOF) are not supported for T1 or T2 instances.
+	//
+	//    * Redis Multi-AZ with automatic failover is not supported on T1 instances.
+	//
+	//    * Redis configuration variables appendonly and appendfsync are not supported
+	//    on Redis version 2.8.22 and later.
+	CacheNodeType *string `json:"cacheNodeType,omitempty"`
+	// The cache parameter group that is associated with the source cluster.
+	CacheParameterGroupName *string `json:"cacheParameterGroupName,omitempty"`
+	// The name of the cache subnet group associated with the source cluster.
+	CacheSubnetGroupName *string `json:"cacheSubnetGroupName,omitempty"`
+	// The name of the cache engine (memcached or redis) used by the source cluster.
+	Engine *string `json:"engine,omitempty"`
+	// The version of the cache engine version that is used by the source cluster.
+	EngineVersion *string `json:"engineVersion,omitempty"`
+	// A list of the cache nodes in the source cluster.
+	NodeSnapshots []*NodeSnapshot `json:"nodeSnapshots,omitempty"`
+	// The number of cache nodes in the source cluster.
+	//
+	// For clusters running Redis, this value must be 1. For clusters running Memcached,
+	// this value must be between 1 and 20.
+	NumCacheNodes *int64 `json:"numCacheNodes,omitempty"`
+	// The number of node groups (shards) in this snapshot. When restoring from
+	// a snapshot, the number of node groups (shards) in the snapshot and in the
+	// restored replication group must be the same.
+	NumNodeGroups *int64 `json:"numNodeGroups,omitempty"`
+	// The port number used by each cache nodes in the source cluster.
+	Port *int64 `json:"port,omitempty"`
+	// The name of the Availability Zone in which the source cluster is located.
+	PreferredAvailabilityZone *string `json:"preferredAvailabilityZone,omitempty"`
+	// Specifies the weekly time range during which maintenance on the cluster is
+	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+	// (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+	//
+	// Valid values for ddd are:
+	//
+	//    * sun
+	//
+	//    * mon
+	//
+	//    * tue
+	//
+	//    * wed
+	//
+	//    * thu
+	//
+	//    * fri
+	//
+	//    * sat
+	//
+	// Example: sun:23:00-mon:01:30
+	PreferredMaintenanceWindow *string `json:"preferredMaintenanceWindow,omitempty"`
+	// The ARN (Amazon Resource Name) of the preferred outpost.
+	PreferredOutpostARN *string `json:"preferredOutpostARN,omitempty"`
+	// A description of the source replication group.
+	ReplicationGroupDescription *string `json:"replicationGroupDescription,omitempty"`
+	// For an automatic snapshot, the number of days for which ElastiCache retains
+	// the snapshot before deleting it.
+	//
+	// For manual snapshots, this field reflects the SnapshotRetentionLimit for
+	// the source cluster when the snapshot was created. This field is otherwise
+	// ignored: Manual snapshots do not expire, and can only be deleted using the
+	// DeleteSnapshot operation.
+	//
+	// Important If the value of SnapshotRetentionLimit is set to zero (0), backups
+	// are turned off.
+	SnapshotRetentionLimit *int64 `json:"snapshotRetentionLimit,omitempty"`
+	// Indicates whether the snapshot is from an automatic backup (automated) or
+	// was created manually (manual).
+	SnapshotSource *string `json:"snapshotSource,omitempty"`
+	// The status of the snapshot. Valid values: creating | available | restoring
+	// | copying | deleting.
+	SnapshotStatus *string `json:"snapshotStatus,omitempty"`
+	// The daily time range during which ElastiCache takes daily snapshots of the
+	// source cluster.
+	SnapshotWindow *string `json:"snapshotWindow,omitempty"`
+	// The Amazon Resource Name (ARN) for the topic used by the source cluster for
+	// publishing notifications.
+	TopicARN *string `json:"topicARN,omitempty"`
+	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
+	// group for the source cluster.
+	VPCID *string `json:"vpcID,omitempty"`
 }
 
 // Snapshot is the Schema for the Snapshots API

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -16,42 +16,57 @@
 package v1alpha1
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Hack to avoid import errors during build...
+var (
+	_ = &metav1.Time{}
+	_ = &aws.JSONValue{}
+	_ = ackv1alpha1.AWSAccountID("")
+)
+
+// Indicates whether the user requires a password to authenticate.
 type Authentication struct {
 	PasswordCount *int64 `json:"passwordCount,omitempty"`
 }
 
+// Describes an Availability Zone in which the cluster is launched.
 type AvailabilityZone struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// Contains all of the attributes of a specific cluster.
 type CacheCluster struct {
-	ARN                        *string      `json:"arn,omitempty"`
-	AtRestEncryptionEnabled    *bool        `json:"atRestEncryptionEnabled,omitempty"`
-	AuthTokenEnabled           *bool        `json:"authTokenEnabled,omitempty"`
-	AuthTokenLastModifiedDate  *metav1.Time `json:"authTokenLastModifiedDate,omitempty"`
-	AutoMinorVersionUpgrade    *bool        `json:"autoMinorVersionUpgrade,omitempty"`
-	CacheClusterCreateTime     *metav1.Time `json:"cacheClusterCreateTime,omitempty"`
-	CacheClusterID             *string      `json:"cacheClusterID,omitempty"`
-	CacheClusterStatus         *string      `json:"cacheClusterStatus,omitempty"`
-	CacheNodeType              *string      `json:"cacheNodeType,omitempty"`
-	CacheSubnetGroupName       *string      `json:"cacheSubnetGroupName,omitempty"`
-	ClientDownloadLandingPage  *string      `json:"clientDownloadLandingPage,omitempty"`
-	ConfigurationEndpoint      *Endpoint    `json:"configurationEndpoint,omitempty"`
-	Engine                     *string      `json:"engine,omitempty"`
-	EngineVersion              *string      `json:"engineVersion,omitempty"`
-	NumCacheNodes              *int64       `json:"numCacheNodes,omitempty"`
-	PreferredAvailabilityZone  *string      `json:"preferredAvailabilityZone,omitempty"`
-	PreferredMaintenanceWindow *string      `json:"preferredMaintenanceWindow,omitempty"`
-	PreferredOutpostARN        *string      `json:"preferredOutpostARN,omitempty"`
-	ReplicationGroupID         *string      `json:"replicationGroupID,omitempty"`
-	SnapshotRetentionLimit     *int64       `json:"snapshotRetentionLimit,omitempty"`
-	SnapshotWindow             *string      `json:"snapshotWindow,omitempty"`
-	TransitEncryptionEnabled   *bool        `json:"transitEncryptionEnabled,omitempty"`
+	ARN                       *string      `json:"arn,omitempty"`
+	AtRestEncryptionEnabled   *bool        `json:"atRestEncryptionEnabled,omitempty"`
+	AuthTokenEnabled          *bool        `json:"authTokenEnabled,omitempty"`
+	AuthTokenLastModifiedDate *metav1.Time `json:"authTokenLastModifiedDate,omitempty"`
+	AutoMinorVersionUpgrade   *bool        `json:"autoMinorVersionUpgrade,omitempty"`
+	CacheClusterCreateTime    *metav1.Time `json:"cacheClusterCreateTime,omitempty"`
+	CacheClusterID            *string      `json:"cacheClusterID,omitempty"`
+	CacheClusterStatus        *string      `json:"cacheClusterStatus,omitempty"`
+	CacheNodeType             *string      `json:"cacheNodeType,omitempty"`
+	CacheSubnetGroupName      *string      `json:"cacheSubnetGroupName,omitempty"`
+	ClientDownloadLandingPage *string      `json:"clientDownloadLandingPage,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	ConfigurationEndpoint      *Endpoint `json:"configurationEndpoint,omitempty"`
+	Engine                     *string   `json:"engine,omitempty"`
+	EngineVersion              *string   `json:"engineVersion,omitempty"`
+	NumCacheNodes              *int64    `json:"numCacheNodes,omitempty"`
+	PreferredAvailabilityZone  *string   `json:"preferredAvailabilityZone,omitempty"`
+	PreferredMaintenanceWindow *string   `json:"preferredMaintenanceWindow,omitempty"`
+	PreferredOutpostARN        *string   `json:"preferredOutpostARN,omitempty"`
+	ReplicationGroupID         *string   `json:"replicationGroupID,omitempty"`
+	SnapshotRetentionLimit     *int64    `json:"snapshotRetentionLimit,omitempty"`
+	SnapshotWindow             *string   `json:"snapshotWindow,omitempty"`
+	TransitEncryptionEnabled   *bool     `json:"transitEncryptionEnabled,omitempty"`
 }
 
+// Provides all of the details about a particular cache engine version.
 type CacheEngineVersion struct {
 	CacheEngineDescription        *string `json:"cacheEngineDescription,omitempty"`
 	CacheEngineVersionDescription *string `json:"cacheEngineVersionDescription,omitempty"`
@@ -60,17 +75,69 @@ type CacheEngineVersion struct {
 	EngineVersion                 *string `json:"engineVersion,omitempty"`
 }
 
+// Represents an individual cache node within a cluster. Each cache node runs
+// its own instance of the cluster's protocol-compliant caching software - either
+// Memcached or Redis.
+//
+// The following node types are supported by ElastiCache. Generally speaking,
+// the current generation types provide more memory and computational power
+// at lower cost when compared to their equivalent previous generation counterparts.
+//
+//    * General purpose: Current generation: M6g node types (available only
+//    for Redis engine version 5.0.6 onward and for Memcached engine version
+//    1.5.16 onward). cache.m6g.large, cache.m6g.xlarge, cache.m6g.2xlarge,
+//    cache.m6g.4xlarge, cache.m6g.8xlarge, cache.m6g.12xlarge, cache.m6g.16xlarge
+//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+//    M5 node types: cache.m5.large, cache.m5.xlarge, cache.m5.2xlarge, cache.m5.4xlarge,
+//    cache.m5.12xlarge, cache.m5.24xlarge M4 node types: cache.m4.large, cache.m4.xlarge,
+//    cache.m4.2xlarge, cache.m4.4xlarge, cache.m4.10xlarge T3 node types: cache.t3.micro,
+//    cache.t3.small, cache.t3.medium T2 node types: cache.t2.micro, cache.t2.small,
+//    cache.t2.medium Previous generation: (not recommended) T1 node types:
+//    cache.t1.micro M1 node types: cache.m1.small, cache.m1.medium, cache.m1.large,
+//    cache.m1.xlarge M3 node types: cache.m3.medium, cache.m3.large, cache.m3.xlarge,
+//    cache.m3.2xlarge
+//
+//    * Compute optimized: Previous generation: (not recommended) C1 node types:
+//    cache.c1.xlarge
+//
+//    * Memory optimized: Current generation: R6g node types (available only
+//    for Redis engine version 5.0.6 onward and for Memcached engine version
+//    1.5.16 onward). cache.r6g.large, cache.r6g.xlarge, cache.r6g.2xlarge,
+//    cache.r6g.4xlarge, cache.r6g.8xlarge, cache.r6g.12xlarge, cache.r6g.16xlarge
+//    For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+//    R5 node types: cache.r5.large, cache.r5.xlarge, cache.r5.2xlarge, cache.r5.4xlarge,
+//    cache.r5.12xlarge, cache.r5.24xlarge R4 node types: cache.r4.large, cache.r4.xlarge,
+//    cache.r4.2xlarge, cache.r4.4xlarge, cache.r4.8xlarge, cache.r4.16xlarge
+//    Previous generation: (not recommended) M2 node types: cache.m2.xlarge,
+//    cache.m2.2xlarge, cache.m2.4xlarge R3 node types: cache.r3.large, cache.r3.xlarge,
+//    cache.r3.2xlarge, cache.r3.4xlarge, cache.r3.8xlarge
+//
+// Additional node type info
+//
+//    * All current generation instance types are created in Amazon VPC by default.
+//
+//    * Redis append-only files (AOF) are not supported for T1 or T2 instances.
+//
+//    * Redis Multi-AZ with automatic failover is not supported on T1 instances.
+//
+//    * Redis configuration variables appendonly and appendfsync are not supported
+//    on Redis version 2.8.22 and later.
 type CacheNode struct {
 	CacheNodeCreateTime      *metav1.Time `json:"cacheNodeCreateTime,omitempty"`
 	CacheNodeID              *string      `json:"cacheNodeID,omitempty"`
 	CacheNodeStatus          *string      `json:"cacheNodeStatus,omitempty"`
 	CustomerAvailabilityZone *string      `json:"customerAvailabilityZone,omitempty"`
 	CustomerOutpostARN       *string      `json:"customerOutpostARN,omitempty"`
-	Endpoint                 *Endpoint    `json:"endpoint,omitempty"`
-	ParameterGroupStatus     *string      `json:"parameterGroupStatus,omitempty"`
-	SourceCacheNodeID        *string      `json:"sourceCacheNodeID,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	Endpoint             *Endpoint `json:"endpoint,omitempty"`
+	ParameterGroupStatus *string   `json:"parameterGroupStatus,omitempty"`
+	SourceCacheNodeID    *string   `json:"sourceCacheNodeID,omitempty"`
 }
 
+// A parameter that has a different value for each cache node type it is applied
+// to. For example, in a Redis cluster, a cache.m1.large cache node type would
+// have a larger maxmemory value than a cache.m1.small type.
 type CacheNodeTypeSpecificParameter struct {
 	AllowedValues        *string `json:"allowedValues,omitempty"`
 	DataType             *string `json:"dataType,omitempty"`
@@ -81,11 +148,13 @@ type CacheNodeTypeSpecificParameter struct {
 	Source               *string `json:"source,omitempty"`
 }
 
+// A value that applies only to a certain cache node type.
 type CacheNodeTypeSpecificValue struct {
 	CacheNodeType *string `json:"cacheNodeType,omitempty"`
 	Value         *string `json:"value,omitempty"`
 }
 
+// The status of the service update on the cache node
 type CacheNodeUpdateStatus struct {
 	CacheNodeID                  *string      `json:"cacheNodeID,omitempty"`
 	NodeDeletionDate             *metav1.Time `json:"nodeDeletionDate,omitempty"`
@@ -95,11 +164,13 @@ type CacheNodeUpdateStatus struct {
 	NodeUpdateStatusModifiedDate *metav1.Time `json:"nodeUpdateStatusModifiedDate,omitempty"`
 }
 
+// Status of the cache parameter group.
 type CacheParameterGroupStatus_SDK struct {
 	CacheParameterGroupName *string `json:"cacheParameterGroupName,omitempty"`
 	ParameterApplyStatus    *string `json:"parameterApplyStatus,omitempty"`
 }
 
+// Represents the output of a CreateCacheParameterGroup operation.
 type CacheParameterGroup_SDK struct {
 	ARN                       *string `json:"arn,omitempty"`
 	CacheParameterGroupFamily *string `json:"cacheParameterGroupFamily,omitempty"`
@@ -108,6 +179,13 @@ type CacheParameterGroup_SDK struct {
 	IsGlobal                  *bool   `json:"isGlobal,omitempty"`
 }
 
+// Represents the output of one of the following operations:
+//
+//    * AuthorizeCacheSecurityGroupIngress
+//
+//    * CreateCacheSecurityGroup
+//
+//    * RevokeCacheSecurityGroupIngress
 type CacheSecurityGroup struct {
 	ARN                    *string `json:"arn,omitempty"`
 	CacheSecurityGroupName *string `json:"cacheSecurityGroupName,omitempty"`
@@ -115,11 +193,17 @@ type CacheSecurityGroup struct {
 	OwnerID                *string `json:"ownerID,omitempty"`
 }
 
+// Represents a cluster's status within a particular cache security group.
 type CacheSecurityGroupMembership struct {
 	CacheSecurityGroupName *string `json:"cacheSecurityGroupName,omitempty"`
 	Status                 *string `json:"status,omitempty"`
 }
 
+// Represents the output of one of the following operations:
+//
+//    * CreateCacheSubnetGroup
+//
+//    * ModifyCacheSubnetGroup
 type CacheSubnetGroup_SDK struct {
 	ARN                         *string   `json:"arn,omitempty"`
 	CacheSubnetGroupDescription *string   `json:"cacheSubnetGroupDescription,omitempty"`
@@ -128,43 +212,62 @@ type CacheSubnetGroup_SDK struct {
 	VPCID                       *string   `json:"vpcID,omitempty"`
 }
 
+// Node group (shard) configuration options when adding or removing replicas.
+// Each node group (shard) configuration has the following members: NodeGroupId,
+// NewReplicaCount, and PreferredAvailabilityZones.
 type ConfigureShard struct {
 	NewReplicaCount *int64  `json:"newReplicaCount,omitempty"`
 	NodeGroupID     *string `json:"nodeGroupID,omitempty"`
 }
 
+// The endpoint from which data should be migrated.
 type CustomerNodeEndpoint struct {
 	Address *string `json:"address,omitempty"`
 	Port    *int64  `json:"port,omitempty"`
 }
 
+// Provides ownership and status information for an Amazon EC2 security group.
 type EC2SecurityGroup struct {
 	EC2SecurityGroupName    *string `json:"ec2SecurityGroupName,omitempty"`
 	EC2SecurityGroupOwnerID *string `json:"ec2SecurityGroupOwnerID,omitempty"`
 	Status                  *string `json:"status,omitempty"`
 }
 
+// Represents the information required for client programs to connect to a cache
+// node.
 type Endpoint struct {
 	Address *string `json:"address,omitempty"`
 	Port    *int64  `json:"port,omitempty"`
 }
 
+// Represents the output of a DescribeEngineDefaultParameters operation.
 type EngineDefaults struct {
 	CacheParameterGroupFamily *string `json:"cacheParameterGroupFamily,omitempty"`
 	Marker                    *string `json:"marker,omitempty"`
 }
 
+// Represents a single occurrence of something interesting within the system.
+// Some examples of events are creating a cluster, adding or removing a cache
+// node, or rebooting a node.
 type Event struct {
 	Date             *metav1.Time `json:"date,omitempty"`
 	Message          *string      `json:"message,omitempty"`
 	SourceIdentifier *string      `json:"sourceIdentifier,omitempty"`
 }
 
+// Indicates the slot configuration and global identifier for a slice group.
 type GlobalNodeGroup struct {
 	GlobalNodeGroupID *string `json:"globalNodeGroupID,omitempty"`
 	Slots             *string `json:"slots,omitempty"`
 }
 
+// Consists of a primary cluster that accepts writes and an associated secondary
+// cluster that resides in a different AWS region. The secondary cluster accepts
+// only reads. The primary cluster automatically replicates updates to the secondary
+// cluster.
+//
+//    * The GlobalReplicationGroupIdSuffix represents the name of the Global
+//    Datastore, which is what you use to associate a secondary cluster.
 type GlobalReplicationGroup struct {
 	ARN                               *string `json:"arn,omitempty"`
 	AtRestEncryptionEnabled           *bool   `json:"atRestEncryptionEnabled,omitempty"`
@@ -179,11 +282,15 @@ type GlobalReplicationGroup struct {
 	TransitEncryptionEnabled          *bool   `json:"transitEncryptionEnabled,omitempty"`
 }
 
+// The name of the Global Datastore and role of this replication group in the
+// Global Datastore.
 type GlobalReplicationGroupInfo struct {
 	GlobalReplicationGroupID         *string `json:"globalReplicationGroupID,omitempty"`
 	GlobalReplicationGroupMemberRole *string `json:"globalReplicationGroupMemberRole,omitempty"`
 }
 
+// A member of a Global Datastore. It contains the Replication Group Id, the
+// AWS region and the role of the replication group.
 type GlobalReplicationGroupMember struct {
 	AutomaticFailover      *string `json:"automaticFailover,omitempty"`
 	ReplicationGroupID     *string `json:"replicationGroupID,omitempty"`
@@ -192,15 +299,25 @@ type GlobalReplicationGroupMember struct {
 	Status                 *string `json:"status,omitempty"`
 }
 
+// Represents a collection of cache nodes in a replication group. One node in
+// the node group is the read/write primary node. All the other nodes are read-only
+// Replica nodes.
 type NodeGroup struct {
 	NodeGroupID      *string            `json:"nodeGroupID,omitempty"`
 	NodeGroupMembers []*NodeGroupMember `json:"nodeGroupMembers,omitempty"`
-	PrimaryEndpoint  *Endpoint          `json:"primaryEndpoint,omitempty"`
-	ReaderEndpoint   *Endpoint          `json:"readerEndpoint,omitempty"`
-	Slots            *string            `json:"slots,omitempty"`
-	Status           *string            `json:"status,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	PrimaryEndpoint *Endpoint `json:"primaryEndpoint,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	ReaderEndpoint *Endpoint `json:"readerEndpoint,omitempty"`
+	Slots          *string   `json:"slots,omitempty"`
+	Status         *string   `json:"status,omitempty"`
 }
 
+// Node group (shard) configuration options. Each node group (shard) configuration
+// has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones,
+// ReplicaCount.
 type NodeGroupConfiguration struct {
 	NodeGroupID              *string   `json:"nodeGroupID,omitempty"`
 	PrimaryAvailabilityZone  *string   `json:"primaryAvailabilityZone,omitempty"`
@@ -211,15 +328,19 @@ type NodeGroupConfiguration struct {
 	Slots                    *string   `json:"slots,omitempty"`
 }
 
+// Represents a single node within a node group (shard).
 type NodeGroupMember struct {
-	CacheClusterID            *string   `json:"cacheClusterID,omitempty"`
-	CacheNodeID               *string   `json:"cacheNodeID,omitempty"`
-	CurrentRole               *string   `json:"currentRole,omitempty"`
-	PreferredAvailabilityZone *string   `json:"preferredAvailabilityZone,omitempty"`
-	PreferredOutpostARN       *string   `json:"preferredOutpostARN,omitempty"`
-	ReadEndpoint              *Endpoint `json:"readEndpoint,omitempty"`
+	CacheClusterID            *string `json:"cacheClusterID,omitempty"`
+	CacheNodeID               *string `json:"cacheNodeID,omitempty"`
+	CurrentRole               *string `json:"currentRole,omitempty"`
+	PreferredAvailabilityZone *string `json:"preferredAvailabilityZone,omitempty"`
+	PreferredOutpostARN       *string `json:"preferredOutpostARN,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	ReadEndpoint *Endpoint `json:"readEndpoint,omitempty"`
 }
 
+// The status of the service update on the node group member
 type NodeGroupMemberUpdateStatus struct {
 	CacheClusterID               *string      `json:"cacheClusterID,omitempty"`
 	CacheNodeID                  *string      `json:"cacheNodeID,omitempty"`
@@ -230,25 +351,35 @@ type NodeGroupMemberUpdateStatus struct {
 	NodeUpdateStatusModifiedDate *metav1.Time `json:"nodeUpdateStatusModifiedDate,omitempty"`
 }
 
+// The status of the service update on the node group
 type NodeGroupUpdateStatus struct {
 	NodeGroupID *string `json:"nodeGroupID,omitempty"`
 }
 
+// Represents an individual cache node in a snapshot of a cluster.
 type NodeSnapshot struct {
-	CacheClusterID         *string                 `json:"cacheClusterID,omitempty"`
-	CacheNodeCreateTime    *metav1.Time            `json:"cacheNodeCreateTime,omitempty"`
-	CacheNodeID            *string                 `json:"cacheNodeID,omitempty"`
-	CacheSize              *string                 `json:"cacheSize,omitempty"`
+	CacheClusterID      *string      `json:"cacheClusterID,omitempty"`
+	CacheNodeCreateTime *metav1.Time `json:"cacheNodeCreateTime,omitempty"`
+	CacheNodeID         *string      `json:"cacheNodeID,omitempty"`
+	CacheSize           *string      `json:"cacheSize,omitempty"`
+	// Node group (shard) configuration options. Each node group (shard) configuration
+	// has the following: Slots, PrimaryAvailabilityZone, ReplicaAvailabilityZones,
+	// ReplicaCount.
 	NodeGroupConfiguration *NodeGroupConfiguration `json:"nodeGroupConfiguration,omitempty"`
 	NodeGroupID            *string                 `json:"nodeGroupID,omitempty"`
 	SnapshotCreateTime     *metav1.Time            `json:"snapshotCreateTime,omitempty"`
 }
 
+// Describes a notification topic and its status. Notification topics are used
+// for publishing ElastiCache events to subscribers using Amazon Simple Notification
+// Service (SNS).
 type NotificationConfiguration struct {
 	TopicARN    *string `json:"topicARN,omitempty"`
 	TopicStatus *string `json:"topicStatus,omitempty"`
 }
 
+// Describes an individual setting that controls some aspect of ElastiCache
+// behavior.
 type Parameter struct {
 	AllowedValues        *string `json:"allowedValues,omitempty"`
 	DataType             *string `json:"dataType,omitempty"`
@@ -260,11 +391,14 @@ type Parameter struct {
 	Source               *string `json:"source,omitempty"`
 }
 
+// Describes a name-value pair that is used to update the value of a parameter.
 type ParameterNameValue struct {
 	ParameterName  *string `json:"parameterName,omitempty"`
 	ParameterValue *string `json:"parameterValue,omitempty"`
 }
 
+// A group of settings that are applied to the cluster in the future, or that
+// are currently being applied.
 type PendingModifiedValues struct {
 	AuthTokenStatus *string `json:"authTokenStatus,omitempty"`
 	CacheNodeType   *string `json:"cacheNodeType,omitempty"`
@@ -272,56 +406,72 @@ type PendingModifiedValues struct {
 	NumCacheNodes   *int64  `json:"numCacheNodes,omitempty"`
 }
 
+// Update action that has been processed for the corresponding apply/stop request
 type ProcessedUpdateAction struct {
 	CacheClusterID     *string `json:"cacheClusterID,omitempty"`
 	ReplicationGroupID *string `json:"replicationGroupID,omitempty"`
 	ServiceUpdateName  *string `json:"serviceUpdateName,omitempty"`
 }
 
+// Contains the specific price and frequency of a recurring charges for a reserved
+// cache node, or for a reserved cache node offering.
 type RecurringCharge struct {
 	RecurringChargeAmount    *float64 `json:"recurringChargeAmount,omitempty"`
 	RecurringChargeFrequency *string  `json:"recurringChargeFrequency,omitempty"`
 }
 
+// A list of the replication groups
 type RegionalConfiguration struct {
 	ReplicationGroupID     *string `json:"replicationGroupID,omitempty"`
 	ReplicationGroupRegion *string `json:"replicationGroupRegion,omitempty"`
 }
 
+// The settings to be applied to the Redis replication group, either immediately
+// or during the next maintenance window.
 type ReplicationGroupPendingModifiedValues struct {
-	AuthTokenStatus         *string                 `json:"authTokenStatus,omitempty"`
-	AutomaticFailoverStatus *string                 `json:"automaticFailoverStatus,omitempty"`
-	PrimaryClusterID        *string                 `json:"primaryClusterID,omitempty"`
-	Resharding              *ReshardingStatus       `json:"resharding,omitempty"`
-	UserGroups              *UserGroupsUpdateStatus `json:"userGroups,omitempty"`
+	AuthTokenStatus         *string `json:"authTokenStatus,omitempty"`
+	AutomaticFailoverStatus *string `json:"automaticFailoverStatus,omitempty"`
+	PrimaryClusterID        *string `json:"primaryClusterID,omitempty"`
+	// The status of an online resharding operation.
+	Resharding *ReshardingStatus `json:"resharding,omitempty"`
+	// The status of the user group update.
+	UserGroups *UserGroupsUpdateStatus `json:"userGroups,omitempty"`
 }
 
+// Contains all of the attributes of a specific Redis replication group.
 type ReplicationGroup_SDK struct {
-	ARN                        *string                                `json:"arn,omitempty"`
-	AtRestEncryptionEnabled    *bool                                  `json:"atRestEncryptionEnabled,omitempty"`
-	AuthTokenEnabled           *bool                                  `json:"authTokenEnabled,omitempty"`
-	AuthTokenLastModifiedDate  *metav1.Time                           `json:"authTokenLastModifiedDate,omitempty"`
-	AutomaticFailover          *string                                `json:"automaticFailover,omitempty"`
-	CacheNodeType              *string                                `json:"cacheNodeType,omitempty"`
-	ClusterEnabled             *bool                                  `json:"clusterEnabled,omitempty"`
-	ConfigurationEndpoint      *Endpoint                              `json:"configurationEndpoint,omitempty"`
-	Description                *string                                `json:"description,omitempty"`
-	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo            `json:"globalReplicationGroupInfo,omitempty"`
-	KMSKeyID                   *string                                `json:"kmsKeyID,omitempty"`
-	MemberClusters             []*string                              `json:"memberClusters,omitempty"`
-	MemberClustersOutpostARNs  []*string                              `json:"memberClustersOutpostARNs,omitempty"`
-	MultiAZ                    *string                                `json:"multiAZ,omitempty"`
-	NodeGroups                 []*NodeGroup                           `json:"nodeGroups,omitempty"`
-	PendingModifiedValues      *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
-	ReplicationGroupID         *string                                `json:"replicationGroupID,omitempty"`
-	SnapshotRetentionLimit     *int64                                 `json:"snapshotRetentionLimit,omitempty"`
-	SnapshotWindow             *string                                `json:"snapshotWindow,omitempty"`
-	SnapshottingClusterID      *string                                `json:"snapshottingClusterID,omitempty"`
-	Status                     *string                                `json:"status,omitempty"`
-	TransitEncryptionEnabled   *bool                                  `json:"transitEncryptionEnabled,omitempty"`
-	UserGroupIDs               []*string                              `json:"userGroupIDs,omitempty"`
+	ARN                       *string      `json:"arn,omitempty"`
+	AtRestEncryptionEnabled   *bool        `json:"atRestEncryptionEnabled,omitempty"`
+	AuthTokenEnabled          *bool        `json:"authTokenEnabled,omitempty"`
+	AuthTokenLastModifiedDate *metav1.Time `json:"authTokenLastModifiedDate,omitempty"`
+	AutomaticFailover         *string      `json:"automaticFailover,omitempty"`
+	CacheNodeType             *string      `json:"cacheNodeType,omitempty"`
+	ClusterEnabled            *bool        `json:"clusterEnabled,omitempty"`
+	// Represents the information required for client programs to connect to a cache
+	// node.
+	ConfigurationEndpoint *Endpoint `json:"configurationEndpoint,omitempty"`
+	Description           *string   `json:"description,omitempty"`
+	// The name of the Global Datastore and role of this replication group in the
+	// Global Datastore.
+	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo `json:"globalReplicationGroupInfo,omitempty"`
+	KMSKeyID                   *string                     `json:"kmsKeyID,omitempty"`
+	MemberClusters             []*string                   `json:"memberClusters,omitempty"`
+	MemberClustersOutpostARNs  []*string                   `json:"memberClustersOutpostARNs,omitempty"`
+	MultiAZ                    *string                     `json:"multiAZ,omitempty"`
+	NodeGroups                 []*NodeGroup                `json:"nodeGroups,omitempty"`
+	// The settings to be applied to the Redis replication group, either immediately
+	// or during the next maintenance window.
+	PendingModifiedValues    *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
+	ReplicationGroupID       *string                                `json:"replicationGroupID,omitempty"`
+	SnapshotRetentionLimit   *int64                                 `json:"snapshotRetentionLimit,omitempty"`
+	SnapshotWindow           *string                                `json:"snapshotWindow,omitempty"`
+	SnapshottingClusterID    *string                                `json:"snapshottingClusterID,omitempty"`
+	Status                   *string                                `json:"status,omitempty"`
+	TransitEncryptionEnabled *bool                                  `json:"transitEncryptionEnabled,omitempty"`
+	UserGroupIDs             []*string                              `json:"userGroupIDs,omitempty"`
 }
 
+// Represents the output of a PurchaseReservedCacheNodesOffering operation.
 type ReservedCacheNode struct {
 	CacheNodeCount               *int64       `json:"cacheNodeCount,omitempty"`
 	CacheNodeType                *string      `json:"cacheNodeType,omitempty"`
@@ -337,6 +487,7 @@ type ReservedCacheNode struct {
 	UsagePrice                   *float64     `json:"usagePrice,omitempty"`
 }
 
+// Describes all of the attributes of a reserved cache node offering.
 type ReservedCacheNodesOffering struct {
 	CacheNodeType                *string  `json:"cacheNodeType,omitempty"`
 	Duration                     *int64   `json:"duration,omitempty"`
@@ -347,20 +498,26 @@ type ReservedCacheNodesOffering struct {
 	UsagePrice                   *float64 `json:"usagePrice,omitempty"`
 }
 
+// A list of PreferredAvailabilityZones objects that specifies the configuration
+// of a node group in the resharded cluster.
 type ReshardingConfiguration struct {
 	NodeGroupID                *string   `json:"nodeGroupID,omitempty"`
 	PreferredAvailabilityZones []*string `json:"preferredAvailabilityZones,omitempty"`
 }
 
+// The status of an online resharding operation.
 type ReshardingStatus struct {
+	// Represents the progress of an online resharding operation.
 	SlotMigration *SlotMigration `json:"slotMigration,omitempty"`
 }
 
+// Represents a single cache security group and its status.
 type SecurityGroupMembership struct {
 	SecurityGroupID *string `json:"securityGroupID,omitempty"`
 	Status          *string `json:"status,omitempty"`
 }
 
+// An update that you can apply to your Redis clusters.
 type ServiceUpdate struct {
 	AutoUpdateAfterRecommendedApplyByDate *bool        `json:"autoUpdateAfterRecommendedApplyByDate,omitempty"`
 	Engine                                *string      `json:"engine,omitempty"`
@@ -373,10 +530,13 @@ type ServiceUpdate struct {
 	ServiceUpdateReleaseDate              *metav1.Time `json:"serviceUpdateReleaseDate,omitempty"`
 }
 
+// Represents the progress of an online resharding operation.
 type SlotMigration struct {
 	ProgressPercentage *float64 `json:"progressPercentage,omitempty"`
 }
 
+// Represents a copy of an entire Redis cluster as of the time when the snapshot
+// was taken.
 type Snapshot_SDK struct {
 	ARN                         *string         `json:"arn,omitempty"`
 	AutoMinorVersionUpgrade     *bool           `json:"autoMinorVersionUpgrade,omitempty"`
@@ -407,26 +567,39 @@ type Snapshot_SDK struct {
 	VPCID                       *string         `json:"vpcID,omitempty"`
 }
 
+// Represents the subnet associated with a cluster. This parameter refers to
+// subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with
+// ElastiCache.
 type Subnet struct {
+	// Describes an Availability Zone in which the cluster is launched.
 	SubnetAvailabilityZone *AvailabilityZone `json:"subnetAvailabilityZone,omitempty"`
 	SubnetIdentifier       *string           `json:"subnetIdentifier,omitempty"`
-	SubnetOutpost          *SubnetOutpost    `json:"subnetOutpost,omitempty"`
+	// The ID of the outpost subnet.
+	SubnetOutpost *SubnetOutpost `json:"subnetOutpost,omitempty"`
 }
 
+// The ID of the outpost subnet.
 type SubnetOutpost struct {
 	SubnetOutpostARN *string `json:"subnetOutpostARN,omitempty"`
 }
 
+// A cost allocation Tag that can be added to an ElastiCache cluster or replication
+// group. Tags are composed of a Key/Value pair. A tag with a null Value is
+// permitted.
 type Tag struct {
 	Key   *string `json:"key,omitempty"`
 	Value *string `json:"value,omitempty"`
 }
 
+// Filters update actions from the service updates that are in available status
+// during the time range.
 type TimeRangeFilter struct {
 	EndTime   *metav1.Time `json:"endTime,omitempty"`
 	StartTime *metav1.Time `json:"startTime,omitempty"`
 }
 
+// Update action that has failed to be processed for the corresponding apply/stop
+// request
 type UnprocessedUpdateAction struct {
 	CacheClusterID     *string `json:"cacheClusterID,omitempty"`
 	ErrorMessage       *string `json:"errorMessage,omitempty"`
@@ -435,6 +608,7 @@ type UnprocessedUpdateAction struct {
 	ServiceUpdateName  *string `json:"serviceUpdateName,omitempty"`
 }
 
+// The status of the service update for a specific replication group
 type UpdateAction struct {
 	CacheClusterID                      *string      `json:"cacheClusterID,omitempty"`
 	Engine                              *string      `json:"engine,omitempty"`
@@ -463,6 +637,7 @@ type UserGroup struct {
 	UserGroupID *string `json:"userGroupID,omitempty"`
 }
 
+// The status of the user group update.
 type UserGroupsUpdateStatus struct {
 	UserGroupIDsToAdd    []*string `json:"userGroupIDsToAdd,omitempty"`
 	UserGroupIDsToRemove []*string `json:"userGroupIDsToRemove,omitempty"`

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -28,6 +28,7 @@ import (
 
 	svctypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
 	svcresource "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/cache_parameter_group"
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/cache_subnet_group"
@@ -45,6 +46,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = svctypes.AddToScheme(scheme)
+	_ = ackv1alpha1.AddToScheme(scheme)
 }
 
 func main() {
@@ -67,6 +69,7 @@ func main() {
 		MetricsBindAddress: ackCfg.MetricsAddr,
 		LeaderElection:     ackCfg.EnableLeaderElection,
 		LeaderElectionID:   awsServiceAPIGroup,
+		Namespace:          ackCfg.WatchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
         - "$(ACK_RESOURCE_TAGS)"
+        - --watch-namespace
+        - "$(ACK_WATCH_NAMESPACE)"
         image: controller:latest
         name: controller
         ports:

--- a/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
@@ -38,13 +38,26 @@ spec:
             description: CacheParameterGroupSpec defines the desired state of CacheParameterGroup
             properties:
               cacheParameterGroupFamily:
+                description: "The name of the cache parameter group family that the
+                  cache parameter group can be used with. \n Valid values are: memcached1.4
+                  | memcached1.5 | memcached1.6 | redis2.6 | redis2.8 | redis3.2 |
+                  redis4.0 | redis5.0 | redis6.x |"
                 type: string
               cacheParameterGroupName:
+                description: A user-specified name for the cache parameter group.
                 type: string
               description:
+                description: A user-specified description for the cache parameter
+                  group.
                 type: string
               parameterNameValues:
+                description: An array of parameter names and values for the parameter
+                  update. You must supply at least one parameter name and value; subsequent
+                  arguments are optional. A maximum of 20 parameters may be modified
+                  per request.
                 items:
+                  description: Describes a name-value pair that is used to update
+                    the value of a parameter.
                   properties:
                     parameterName:
                       type: string
@@ -117,7 +130,12 @@ spec:
                   type: object
                 type: array
               events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
                 items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster,
+                    adding or removing a cache node, or rebooting a node.
                   properties:
                     date:
                       format: date-time
@@ -129,9 +147,14 @@ spec:
                   type: object
                 type: array
               isGlobal:
+                description: Indicates whether the parameter group is associated with
+                  a Global Datastore
                 type: boolean
               parameters:
+                description: A list of Parameter instances.
                 items:
+                  description: Describes an individual setting that controls some
+                    aspect of ElastiCache behavior.
                   properties:
                     allowedValues:
                       type: string

--- a/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -37,10 +37,15 @@ spec:
             description: CacheSubnetGroupSpec defines the desired state of CacheSubnetGroup
             properties:
               cacheSubnetGroupDescription:
+                description: A description for the cache subnet group.
                 type: string
               cacheSubnetGroupName:
+                description: "A name for the cache subnet group. This value is stored
+                  as a lowercase string. \n Constraints: Must contain no more than
+                  255 alphanumeric characters or hyphens. \n Example: mysubnetgroup"
                 type: string
               subnetIDs:
+                description: A list of VPC subnet IDs for the cache subnet group.
                 items:
                   type: string
                 type: array
@@ -109,7 +114,12 @@ spec:
                   type: object
                 type: array
               events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
                 items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster,
+                    adding or removing a cache node, or rebooting a node.
                   properties:
                     date:
                       format: date-time
@@ -121,9 +131,15 @@ spec:
                   type: object
                 type: array
               subnets:
+                description: A list of subnets associated with the cache subnet group.
                 items:
+                  description: Represents the subnet associated with a cluster. This
+                    parameter refers to subnets defined in Amazon Virtual Private
+                    Cloud (Amazon VPC) and used with ElastiCache.
                   properties:
                     subnetAvailabilityZone:
+                      description: Describes an Availability Zone in which the cluster
+                        is launched.
                       properties:
                         name:
                           type: string
@@ -131,6 +147,7 @@ spec:
                     subnetIdentifier:
                       type: string
                     subnetOutpost:
+                      description: The ID of the outpost subnet.
                       properties:
                         subnetOutpostARN:
                           type: string
@@ -138,6 +155,8 @@ spec:
                   type: object
                 type: array
               vpcID:
+                description: The Amazon Virtual Private Cloud identifier (VPC ID)
+                  of the cache subnet group.
                 type: string
             required:
             - ackResourceMetadata

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -37,10 +37,26 @@ spec:
             description: ReplicationGroupSpec defines the desired state of ReplicationGroup
             properties:
               atRestEncryptionEnabled:
+                description: "A flag that enables encryption at rest when set to true.
+                  \n You cannot modify the value of AtRestEncryptionEnabled after
+                  the replication group is created. To enable encryption at rest on
+                  a replication group you must set AtRestEncryptionEnabled to true
+                  when you create the replication group. \n Required: Only available
+                  when creating a replication group in an Amazon VPC using redis version
+                  3.2.6, 4.x or later. \n Default: false"
                 type: boolean
               authToken:
-                description: SecretKeyReference combines a k8s corev1.SecretReference
-                  with a specific key within the referred-to Secret
+                description: "Reserved parameter. The password used to access a password
+                  protected server. \n AuthToken can be specified only on replication
+                  groups where TransitEncryptionEnabled is true. \n For HIPAA compliance,
+                  you must specify TransitEncryptionEnabled as true, an AuthToken,
+                  and a CacheSubnetGroup. \n Password constraints: \n    * Must be
+                  only printable ASCII characters. \n    * Must be at least 16 characters
+                  and no more than 128 characters in length. \n    * The only permitted
+                  printable special characters are !, &, #, $, ^, <,    >, and -.
+                  Other printable special characters cannot be used in the AUTH    token.
+                  \n For more information, see AUTH password (http://redis.io/commands/AUTH)
+                  at http://redis.io/commands/AUTH."
                 properties:
                   key:
                     description: Key is the key within the secret
@@ -57,29 +73,118 @@ spec:
                 - key
                 type: object
               autoMinorVersionUpgrade:
+                description: This parameter is currently disabled.
                 type: boolean
               automaticFailoverEnabled:
+                description: "Specifies whether a read-only replica is automatically
+                  promoted to read/write primary if the existing primary fails. \n
+                  AutomaticFailoverEnabled must be enabled for Redis (cluster mode
+                  enabled) replication groups. \n Default: false"
                 type: boolean
               cacheNodeType:
+                description: "The compute and memory capacity of the nodes in the
+                  node group (shard). \n The following node types are supported by
+                  ElastiCache. Generally speaking, the current generation types provide
+                  more memory and computational power at lower cost when compared
+                  to their equivalent previous generation counterparts. \n    * General
+                  purpose: Current generation: M6g node types (available only    for
+                  Redis engine version 5.0.6 onward and for Memcached engine version
+                  \   1.5.16 onward). cache.m6g.large, cache.m6g.xlarge, cache.m6g.2xlarge,
+                  \   cache.m6g.4xlarge, cache.m6g.8xlarge, cache.m6g.12xlarge, cache.m6g.16xlarge
+                  \   For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+                  \   M5 node types: cache.m5.large, cache.m5.xlarge, cache.m5.2xlarge,
+                  cache.m5.4xlarge,    cache.m5.12xlarge, cache.m5.24xlarge M4 node
+                  types: cache.m4.large, cache.m4.xlarge,    cache.m4.2xlarge, cache.m4.4xlarge,
+                  cache.m4.10xlarge T3 node types: cache.t3.micro,    cache.t3.small,
+                  cache.t3.medium T2 node types: cache.t2.micro, cache.t2.small,    cache.t2.medium
+                  Previous generation: (not recommended) T1 node types:    cache.t1.micro
+                  M1 node types: cache.m1.small, cache.m1.medium, cache.m1.large,
+                  \   cache.m1.xlarge M3 node types: cache.m3.medium, cache.m3.large,
+                  cache.m3.xlarge,    cache.m3.2xlarge \n    * Compute optimized:
+                  Previous generation: (not recommended) C1 node types:    cache.c1.xlarge
+                  \n    * Memory optimized: Current generation: R6g node types (available
+                  only    for Redis engine version 5.0.6 onward and for Memcached
+                  engine version    1.5.16 onward). cache.r6g.large, cache.r6g.xlarge,
+                  cache.r6g.2xlarge,    cache.r6g.4xlarge, cache.r6g.8xlarge, cache.r6g.12xlarge,
+                  cache.r6g.16xlarge    For region availability, see Supported Node
+                  Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+                  \   R5 node types: cache.r5.large, cache.r5.xlarge, cache.r5.2xlarge,
+                  cache.r5.4xlarge,    cache.r5.12xlarge, cache.r5.24xlarge R4 node
+                  types: cache.r4.large, cache.r4.xlarge,    cache.r4.2xlarge, cache.r4.4xlarge,
+                  cache.r4.8xlarge, cache.r4.16xlarge    Previous generation: (not
+                  recommended) M2 node types: cache.m2.xlarge,    cache.m2.2xlarge,
+                  cache.m2.4xlarge R3 node types: cache.r3.large, cache.r3.xlarge,
+                  \   cache.r3.2xlarge, cache.r3.4xlarge, cache.r3.8xlarge \n Additional
+                  node type info \n    * All current generation instance types are
+                  created in Amazon VPC by default. \n    * Redis append-only files
+                  (AOF) are not supported for T1 or T2 instances. \n    * Redis Multi-AZ
+                  with automatic failover is not supported on T1 instances. \n    *
+                  Redis configuration variables appendonly and appendfsync are not
+                  supported    on Redis version 2.8.22 and later."
                 type: string
               cacheParameterGroupName:
+                description: "The name of the parameter group to associate with this
+                  replication group. If this argument is omitted, the default cache
+                  parameter group for the specified engine is used. \n If you are
+                  running Redis version 3.2.4 or later, only one node group (shard),
+                  and want to use a default parameter group, we recommend that you
+                  specify the parameter group by name. \n    * To create a Redis (cluster
+                  mode disabled) replication group, use CacheParameterGroupName=default.redis3.2.
+                  \n    * To create a Redis (cluster mode enabled) replication group,
+                  use CacheParameterGroupName=default.redis3.2.cluster.on."
                 type: string
               cacheSecurityGroupNames:
+                description: A list of cache security group names to associate with
+                  this replication group.
                 items:
                   type: string
                 type: array
               cacheSubnetGroupName:
+                description: "The name of the cache subnet group to be used for the
+                  replication group. \n If you're going to launch your cluster in
+                  an Amazon VPC, you need to create a subnet group before you start
+                  creating a cluster. For more information, see Subnets and Subnet
+                  Groups (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html)."
                 type: string
               engine:
+                description: The name of the cache engine to be used for the clusters
+                  in this replication group.
                 type: string
               engineVersion:
+                description: "The version number of the cache engine to be used for
+                  the clusters in this replication group. To view the supported cache
+                  engine versions, use the DescribeCacheEngineVersions operation.
+                  \n Important: You can upgrade to a newer engine version (see Selecting
+                  a Cache Engine and Version (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SelectEngine.html#VersionManagement))
+                  in the ElastiCache User Guide, but you cannot downgrade to an earlier
+                  engine version. If you want to use an earlier engine version, you
+                  must delete the existing cluster or replication group and create
+                  it anew with the earlier engine version."
                 type: string
               kmsKeyID:
+                description: The ID of the KMS key used to encrypt the disk in the
+                  cluster.
                 type: string
               multiAZEnabled:
+                description: 'A flag indicating if you have Multi-AZ enabled to enhance
+                  fault tolerance. For more information, see Minimizing Downtime:
+                  Multi-AZ (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html).'
                 type: boolean
               nodeGroupConfiguration:
+                description: "A list of node group (shard) configuration options.
+                  Each node group (shard) configuration has the following members:
+                  PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount,
+                  and Slots. \n If you're creating a Redis (cluster mode disabled)
+                  or a Redis (cluster mode enabled) replication group, you can use
+                  this parameter to individually configure each node group (shard),
+                  or you can omit this parameter. However, it is required when seeding
+                  a Redis (cluster mode enabled) cluster from a S3 rdb file. You must
+                  configure each node group (shard) using this parameter because you
+                  must specify the slots for each node group."
                 items:
+                  description: 'Node group (shard) configuration options. Each node
+                    group (shard) configuration has the following: Slots, PrimaryAvailabilityZone,
+                    ReplicaAvailabilityZones, ReplicaCount.'
                   properties:
                     nodeGroupID:
                       type: string
@@ -103,48 +208,128 @@ spec:
                   type: object
                 type: array
               notificationTopicARN:
+                description: "The Amazon Resource Name (ARN) of the Amazon Simple
+                  Notification Service (SNS) topic to which notifications are sent.
+                  \n The Amazon SNS topic owner must be the same as the cluster owner."
                 type: string
               numCacheClusters:
+                description: "The number of clusters this replication group initially
+                  has. \n This parameter is not used if there is more than one node
+                  group (shard). You should use ReplicasPerNodeGroup instead. \n If
+                  AutomaticFailoverEnabled is true, the value of this parameter must
+                  be at least 2. If AutomaticFailoverEnabled is false you can omit
+                  this parameter (it will default to 1), or you can explicitly set
+                  it to a value between 2 and 6. \n The maximum permitted value for
+                  NumCacheClusters is 6 (1 primary plus 5 replicas)."
                 format: int64
                 type: integer
               numNodeGroups:
+                description: "An optional parameter that specifies the number of node
+                  groups (shards) for this Redis (cluster mode enabled) replication
+                  group. For Redis (cluster mode disabled) either omit this parameter
+                  or set it to 1. \n Default: 1"
                 format: int64
                 type: integer
               port:
+                description: The port number on which each member of the replication
+                  group accepts connections.
                 format: int64
                 type: integer
               preferredCacheClusterAZs:
+                description: "A list of EC2 Availability Zones in which the replication
+                  group's clusters are created. The order of the Availability Zones
+                  in the list is the order in which clusters are allocated. The primary
+                  cluster is created in the first AZ in the list. \n This parameter
+                  is not used if there is more than one node group (shard). You should
+                  use NodeGroupConfiguration instead. \n If you are creating your
+                  replication group in an Amazon VPC (recommended), you can only locate
+                  clusters in Availability Zones associated with the subnets in the
+                  selected subnet group. \n The number of Availability Zones listed
+                  must equal the value of NumCacheClusters. \n Default: system chosen
+                  Availability Zones."
                 items:
                   type: string
                 type: array
               preferredMaintenanceWindow:
+                description: "Specifies the weekly time range during which maintenance
+                  on the cluster is performed. It is specified as a range in the format
+                  ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance
+                  window is a 60 minute period. Valid values for ddd are: \n Specifies
+                  the weekly time range during which maintenance on the cluster is
+                  performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
+                  (24H Clock UTC). The minimum maintenance window is a 60 minute period.
+                  \n Valid values for ddd are: \n    * sun \n    * mon \n    * tue
+                  \n    * wed \n    * thu \n    * fri \n    * sat \n Example: sun:23:00-mon:01:30"
                 type: string
               primaryClusterID:
+                description: "The identifier of the cluster that serves as the primary
+                  for this replication group. This cluster must already exist and
+                  have a status of available. \n This parameter is not required if
+                  NumCacheClusters, NumNodeGroups, or ReplicasPerNodeGroup is specified."
                 type: string
               replicasPerNodeGroup:
+                description: An optional parameter that specifies the number of replica
+                  nodes in each node group (shard). Valid values are 0 to 5.
                 format: int64
                 type: integer
               replicationGroupDescription:
+                description: A user-created description for the replication group.
                 type: string
               replicationGroupID:
+                description: "The replication group identifier. This parameter is
+                  stored as a lowercase string. \n Constraints: \n    * A name must
+                  contain from 1 to 40 alphanumeric characters or hyphens. \n    *
+                  The first character must be a letter. \n    * A name cannot end
+                  with a hyphen or contain two consecutive hyphens."
                 type: string
               securityGroupIDs:
+                description: "One or more Amazon VPC security groups associated with
+                  this replication group. \n Use this parameter only when you are
+                  creating a replication group in an Amazon Virtual Private Cloud
+                  (Amazon VPC)."
                 items:
                   type: string
                 type: array
               snapshotARNs:
+                description: "A list of Amazon Resource Names (ARN) that uniquely
+                  identify the Redis RDB snapshot files stored in Amazon S3. The snapshot
+                  files are used to populate the new replication group. The Amazon
+                  S3 object name in the ARN cannot contain any commas. The new replication
+                  group will have the number of node groups (console: shards) specified
+                  by the parameter NumNodeGroups or the number of node groups configured
+                  by NodeGroupConfiguration regardless of the number of ARNs specified
+                  here. \n Example of an Amazon S3 ARN: arn:aws:s3:::my_bucket/snapshot1.rdb"
                 items:
                   type: string
                 type: array
               snapshotName:
+                description: The name of a snapshot from which to restore data into
+                  the new replication group. The snapshot status changes to restoring
+                  while the new replication group is being created.
                 type: string
               snapshotRetentionLimit:
+                description: "The number of days for which ElastiCache retains automatic
+                  snapshots before deleting them. For example, if you set SnapshotRetentionLimit
+                  to 5, a snapshot that was taken today is retained for 5 days before
+                  being deleted. \n Default: 0 (i.e., automatic backups are disabled
+                  for this cluster)."
                 format: int64
                 type: integer
               snapshotWindow:
+                description: "The daily time range (in UTC) during which ElastiCache
+                  begins taking a daily snapshot of your node group (shard). \n Example:
+                  05:00-09:00 \n If you do not specify this parameter, ElastiCache
+                  automatically chooses an appropriate time range."
                 type: string
               tags:
+                description: 'A list of cost allocation tags to be added to this resource.
+                  Tags are comma-separated key,value pairs (e.g. Key=myKey, Value=myKeyValue.
+                  You can include multiple tags as shown following: Key=myKey, Value=myKeyValue
+                  Key=mySecondKey, Value=mySecondKeyValue.'
                 items:
+                  description: A cost allocation Tag that can be added to an ElastiCache
+                    cluster or replication group. Tags are composed of a Key/Value
+                    pair. A tag with a null Value is permitted.
                   properties:
                     key:
                       type: string
@@ -153,8 +338,22 @@ spec:
                   type: object
                 type: array
               transitEncryptionEnabled:
+                description: "A flag that enables in-transit encryption when set to
+                  true. \n You cannot modify the value of TransitEncryptionEnabled
+                  after the cluster is created. To enable in-transit encryption on
+                  a cluster you must set TransitEncryptionEnabled to true when you
+                  create a cluster. \n This parameter is valid only if the Engine
+                  parameter is redis, the EngineVersion parameter is 3.2.6, 4.x or
+                  later, and the cluster is being created in an Amazon VPC. \n If
+                  you enable in-transit encryption, you must also specify a value
+                  for CacheSubnetGroup. \n Required: Only available when creating
+                  a replication group in an Amazon VPC using redis version 3.2.6,
+                  4.x or later. \n Default: false \n For HIPAA compliance, you must
+                  specify TransitEncryptionEnabled as true, an AuthToken, and a CacheSubnetGroup."
                 type: boolean
               userGroupIDs:
+                description: The list of user groups to associate with the replication
+                  group.
                 items:
                   type: string
                 type: array
@@ -189,21 +388,40 @@ spec:
                 - ownerAccountID
                 type: object
               allowedScaleDownModifications:
+                description: A string list, each element of which specifies a cache
+                  node type which you can use to scale your cluster or replication
+                  group. When scaling down a Redis cluster or replication group using
+                  ModifyCacheCluster or ModifyReplicationGroup, use a value from this
+                  list for the CacheNodeType parameter.
                 items:
                   type: string
                 type: array
               allowedScaleUpModifications:
+                description: "A string list, each element of which specifies a cache
+                  node type which you can use to scale your cluster or replication
+                  group. \n When scaling up a Redis cluster or replication group using
+                  ModifyCacheCluster or ModifyReplicationGroup, use a value from this
+                  list for the CacheNodeType parameter."
                 items:
                   type: string
                 type: array
               authTokenEnabled:
+                description: "A flag that enables using an AuthToken (password) when
+                  issuing Redis commands. \n Default: false"
                 type: boolean
               authTokenLastModifiedDate:
+                description: The date the auth token was last modified
                 format: date-time
                 type: string
               automaticFailover:
+                description: Indicates the status of automatic failover for this Redis
+                  replication group.
                 type: string
               clusterEnabled:
+                description: "A flag indicating whether or not this replication group
+                  is cluster enabled; i.e., whether its data can be partitioned across
+                  multiple shards (API/CLI: node groups). \n Valid values: true |
+                  false"
                 type: boolean
               conditions:
                 description: All CRS managed by ACK have a common `Status.Conditions`
@@ -239,6 +457,8 @@ spec:
                   type: object
                 type: array
               configurationEndpoint:
+                description: The configuration endpoint for this replication group.
+                  Use the configuration endpoint to connect to this replication group.
                 properties:
                   address:
                     type: string
@@ -247,9 +467,15 @@ spec:
                     type: integer
                 type: object
               description:
+                description: The user supplied description of the replication group.
                 type: string
               events:
+                description: A list of events. Each element in the list contains detailed
+                  information about one event.
                 items:
+                  description: Represents a single occurrence of something interesting
+                    within the system. Some examples of events are creating a cluster,
+                    adding or removing a cache node, or rebooting a node.
                   properties:
                     date:
                       format: date-time
@@ -261,6 +487,8 @@ spec:
                   type: object
                 type: array
               globalReplicationGroupInfo:
+                description: The name of the Global Datastore and role of this replication
+                  group in the Global Datastore.
                 properties:
                   globalReplicationGroupID:
                     type: string
@@ -268,22 +496,37 @@ spec:
                     type: string
                 type: object
               memberClusters:
+                description: The names of all the cache clusters that are part of
+                  this replication group.
                 items:
                   type: string
                 type: array
               memberClustersOutpostARNs:
+                description: The outpost ARNs of the replication group's member clusters.
                 items:
                   type: string
                 type: array
               multiAZ:
+                description: 'A flag indicating if you have Multi-AZ enabled to enhance
+                  fault tolerance. For more information, see Minimizing Downtime:
+                  Multi-AZ (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html)'
                 type: string
               nodeGroups:
+                description: A list of node groups in this replication group. For
+                  Redis (cluster mode disabled) replication groups, this is a single-element
+                  list. For Redis (cluster mode enabled) replication groups, the list
+                  contains an entry for each node group (shard).
                 items:
+                  description: Represents a collection of cache nodes in a replication
+                    group. One node in the node group is the read/write primary node.
+                    All the other nodes are read-only Replica nodes.
                   properties:
                     nodeGroupID:
                       type: string
                     nodeGroupMembers:
                       items:
+                        description: Represents a single node within a node group
+                          (shard).
                         properties:
                           cacheClusterID:
                             type: string
@@ -296,6 +539,8 @@ spec:
                           preferredOutpostARN:
                             type: string
                           readEndpoint:
+                            description: Represents the information required for client
+                              programs to connect to a cache node.
                             properties:
                               address:
                                 type: string
@@ -306,6 +551,8 @@ spec:
                         type: object
                       type: array
                     primaryEndpoint:
+                      description: Represents the information required for client
+                        programs to connect to a cache node.
                       properties:
                         address:
                           type: string
@@ -314,6 +561,8 @@ spec:
                           type: integer
                       type: object
                     readerEndpoint:
+                      description: Represents the information required for client
+                        programs to connect to a cache node.
                       properties:
                         address:
                           type: string
@@ -328,6 +577,8 @@ spec:
                   type: object
                 type: array
               pendingModifiedValues:
+                description: A group of settings to be applied to the replication
+                  group, either immediately or during the next maintenance window.
                 properties:
                   authTokenStatus:
                     type: string
@@ -336,14 +587,18 @@ spec:
                   primaryClusterID:
                     type: string
                   resharding:
+                    description: The status of an online resharding operation.
                     properties:
                       slotMigration:
+                        description: Represents the progress of an online resharding
+                          operation.
                         properties:
                           progressPercentage:
                             type: number
                         type: object
                     type: object
                   userGroups:
+                    description: The status of the user group update.
                     properties:
                       userGroupIDsToAdd:
                         items:
@@ -356,8 +611,12 @@ spec:
                     type: object
                 type: object
               snapshottingClusterID:
+                description: The cluster ID that is used as the daily snapshot source
+                  for the replication group.
                 type: string
               status:
+                description: The current state of this replication group - creating,
+                  available, modifying, deleting, create-failed, snapshotting.
                 type: string
             required:
             - ackResourceMetadata

--- a/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
@@ -37,14 +37,22 @@ spec:
             description: SnapshotSpec defines the desired state of Snapshot
             properties:
               cacheClusterID:
+                description: The identifier of an existing cluster. The snapshot is
+                  created from this cluster.
                 type: string
               kmsKeyID:
+                description: The ID of the KMS key used to encrypt the snapshot.
                 type: string
               replicationGroupID:
+                description: The identifier of an existing replication group. The
+                  snapshot is created from this replication group.
                 type: string
               snapshotName:
+                description: A name for the snapshot being created.
                 type: string
               sourceSnapshotName:
+                description: The name of an existing snapshot from which to make a
+                  copy.
                 type: string
             required:
             - snapshotName
@@ -76,17 +84,64 @@ spec:
                 - ownerAccountID
                 type: object
               autoMinorVersionUpgrade:
+                description: This parameter is currently disabled.
                 type: boolean
               automaticFailover:
+                description: Indicates the status of automatic failover for the source
+                  Redis replication group.
                 type: string
               cacheClusterCreateTime:
+                description: The date and time when the source cluster was created.
                 format: date-time
                 type: string
               cacheNodeType:
+                description: "The name of the compute and memory capacity node type
+                  for the source cluster. \n The following node types are supported
+                  by ElastiCache. Generally speaking, the current generation types
+                  provide more memory and computational power at lower cost when compared
+                  to their equivalent previous generation counterparts. \n    * General
+                  purpose: Current generation: M6g node types (available only    for
+                  Redis engine version 5.0.6 onward and for Memcached engine version
+                  \   1.5.16 onward). cache.m6g.large, cache.m6g.xlarge, cache.m6g.2xlarge,
+                  \   cache.m6g.4xlarge, cache.m6g.8xlarge, cache.m6g.12xlarge, cache.m6g.16xlarge
+                  \   For region availability, see Supported Node Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+                  \   M5 node types: cache.m5.large, cache.m5.xlarge, cache.m5.2xlarge,
+                  cache.m5.4xlarge,    cache.m5.12xlarge, cache.m5.24xlarge M4 node
+                  types: cache.m4.large, cache.m4.xlarge,    cache.m4.2xlarge, cache.m4.4xlarge,
+                  cache.m4.10xlarge T3 node types: cache.t3.micro,    cache.t3.small,
+                  cache.t3.medium T2 node types: cache.t2.micro, cache.t2.small,    cache.t2.medium
+                  Previous generation: (not recommended) T1 node types:    cache.t1.micro
+                  M1 node types: cache.m1.small, cache.m1.medium, cache.m1.large,
+                  \   cache.m1.xlarge M3 node types: cache.m3.medium, cache.m3.large,
+                  cache.m3.xlarge,    cache.m3.2xlarge \n    * Compute optimized:
+                  Previous generation: (not recommended) C1 node types:    cache.c1.xlarge
+                  \n    * Memory optimized: Current generation: R6g node types (available
+                  only    for Redis engine version 5.0.6 onward and for Memcached
+                  engine version    1.5.16 onward). cache.r6g.large, cache.r6g.xlarge,
+                  cache.r6g.2xlarge,    cache.r6g.4xlarge, cache.r6g.8xlarge, cache.r6g.12xlarge,
+                  cache.r6g.16xlarge    For region availability, see Supported Node
+                  Types (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html#CacheNodes.SupportedTypesByRegion)
+                  \   R5 node types: cache.r5.large, cache.r5.xlarge, cache.r5.2xlarge,
+                  cache.r5.4xlarge,    cache.r5.12xlarge, cache.r5.24xlarge R4 node
+                  types: cache.r4.large, cache.r4.xlarge,    cache.r4.2xlarge, cache.r4.4xlarge,
+                  cache.r4.8xlarge, cache.r4.16xlarge    Previous generation: (not
+                  recommended) M2 node types: cache.m2.xlarge,    cache.m2.2xlarge,
+                  cache.m2.4xlarge R3 node types: cache.r3.large, cache.r3.xlarge,
+                  \   cache.r3.2xlarge, cache.r3.4xlarge, cache.r3.8xlarge \n Additional
+                  node type info \n    * All current generation instance types are
+                  created in Amazon VPC by default. \n    * Redis append-only files
+                  (AOF) are not supported for T1 or T2 instances. \n    * Redis Multi-AZ
+                  with automatic failover is not supported on T1 instances. \n    *
+                  Redis configuration variables appendonly and appendfsync are not
+                  supported    on Redis version 2.8.22 and later."
                 type: string
               cacheParameterGroupName:
+                description: The cache parameter group that is associated with the
+                  source cluster.
                 type: string
               cacheSubnetGroupName:
+                description: The name of the cache subnet group associated with the
+                  source cluster.
                 type: string
               conditions:
                 description: All CRS managed by ACK have a common `Status.Conditions`
@@ -122,11 +177,18 @@ spec:
                   type: object
                 type: array
               engine:
+                description: The name of the cache engine (memcached or redis) used
+                  by the source cluster.
                 type: string
               engineVersion:
+                description: The version of the cache engine version that is used
+                  by the source cluster.
                 type: string
               nodeSnapshots:
+                description: A list of the cache nodes in the source cluster.
                 items:
+                  description: Represents an individual cache node in a snapshot of
+                    a cluster.
                   properties:
                     cacheClusterID:
                       type: string
@@ -138,6 +200,9 @@ spec:
                     cacheSize:
                       type: string
                     nodeGroupConfiguration:
+                      description: 'Node group (shard) configuration options. Each
+                        node group (shard) configuration has the following: Slots,
+                        PrimaryAvailabilityZone, ReplicaAvailabilityZones, ReplicaCount.'
                       properties:
                         nodeGroupID:
                           type: string
@@ -167,34 +232,70 @@ spec:
                   type: object
                 type: array
               numCacheNodes:
+                description: "The number of cache nodes in the source cluster. \n
+                  For clusters running Redis, this value must be 1. For clusters running
+                  Memcached, this value must be between 1 and 20."
                 format: int64
                 type: integer
               numNodeGroups:
+                description: The number of node groups (shards) in this snapshot.
+                  When restoring from a snapshot, the number of node groups (shards)
+                  in the snapshot and in the restored replication group must be the
+                  same.
                 format: int64
                 type: integer
               port:
+                description: The port number used by each cache nodes in the source
+                  cluster.
                 format: int64
                 type: integer
               preferredAvailabilityZone:
+                description: The name of the Availability Zone in which the source
+                  cluster is located.
                 type: string
               preferredMaintenanceWindow:
+                description: "Specifies the weekly time range during which maintenance
+                  on the cluster is performed. It is specified as a range in the format
+                  ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance
+                  window is a 60 minute period. \n Valid values for ddd are: \n    *
+                  sun \n    * mon \n    * tue \n    * wed \n    * thu \n    * fri
+                  \n    * sat \n Example: sun:23:00-mon:01:30"
                 type: string
               preferredOutpostARN:
+                description: The ARN (Amazon Resource Name) of the preferred outpost.
                 type: string
               replicationGroupDescription:
+                description: A description of the source replication group.
                 type: string
               snapshotRetentionLimit:
+                description: "For an automatic snapshot, the number of days for which
+                  ElastiCache retains the snapshot before deleting it. \n For manual
+                  snapshots, this field reflects the SnapshotRetentionLimit for the
+                  source cluster when the snapshot was created. This field is otherwise
+                  ignored: Manual snapshots do not expire, and can only be deleted
+                  using the DeleteSnapshot operation. \n Important If the value of
+                  SnapshotRetentionLimit is set to zero (0), backups are turned off."
                 format: int64
                 type: integer
               snapshotSource:
+                description: Indicates whether the snapshot is from an automatic backup
+                  (automated) or was created manually (manual).
                 type: string
               snapshotStatus:
+                description: 'The status of the snapshot. Valid values: creating |
+                  available | restoring | copying | deleting.'
                 type: string
               snapshotWindow:
+                description: The daily time range during which ElastiCache takes daily
+                  snapshots of the source cluster.
                 type: string
               topicARN:
+                description: The Amazon Resource Name (ARN) for the topic used by
+                  the source cluster for publishing notifications.
                 type: string
               vpcID:
+                description: The Amazon Virtual Private Cloud identifier (VPC ID)
+                  of the cache subnet group for the source cluster.
                 type: string
             required:
             - ackResourceMetadata

--- a/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
@@ -1,0 +1,227 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: adoptedresources.services.k8s.aws
+spec:
+  group: services.k8s.aws
+  names:
+    kind: AdoptedResource
+    listKind: AdoptedResourceList
+    plural: adoptedresources
+    singular: adoptedresource
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AdoptedResource is the schema for the AdoptedResource API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdoptedResourceSpec defines the desired state of the AdoptedResource.
+            properties:
+              aws:
+                description: AWSIdentifiers provide all unique ways to reference an
+                  AWS resource.
+                properties:
+                  arn:
+                    description: ARN is the AWS Resource Name for the resource. It
+                      is a globally unique identifier.
+                    type: string
+                  nameOrID:
+                    description: NameOrId is a user-supplied string identifier for
+                      the resource. It may or may not be globally unique, depending
+                      on the type of resource.
+                    type: string
+                type: object
+              kubernetes:
+                description: TargetKubernetesResource provides all the values necessary
+                  to identify a given ACK type and override any metadata values when
+                  creating a resource of that type.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  metadata:
+                    description: "ObjectMeta is metadata that all persisted resources
+                      must have, which includes all objects users must create. It
+                      is not possible to use `metav1.ObjectMeta` inside spec, as the
+                      controller-gen automatically converts this to an arbitrary string-string
+                      map. https://github.com/kubernetes-sigs/controller-tools/issues/385
+                      \n Active discussion about inclusion of this field in the spec
+                      is happening in this PR: https://github.com/kubernetes-sigs/controller-tools/pull/395
+                      \n Until this is allowed, or if it never is, we will produce
+                      a subset of the object meta that contains only the fields which
+                      the user is allowed to modify in the metadata."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces"
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL
+                          objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - group
+                - kind
+                type: object
+            required:
+            - aws
+            - kubernetes
+            type: object
+          status:
+            description: AdoptedResourceStatus defines the observed status of the
+              AdoptedResource.
+            properties:
+              conditions:
+                description: A collection of `ackv1alpha1.Condition` objects that
+                  describe the various terminal states of the adopted resource CR
+                  and its target custom resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/common/kustomization.yaml
+++ b/config/crd/common/kustomization.yaml
@@ -1,0 +1,6 @@
+# This file is NOT auto-generated
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/services.k8s.aws_adoptedresources.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+  - common
 resources:
   - bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
   - bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -102,3 +102,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - services.k8s.aws
+  resources:
+  - adoptedresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - services.k8s.aws
+  resources:
+  - adoptedresources/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/elasticache-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.0.5
+	github.com/aws-controllers-k8s/runtime v0.2.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -23,10 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.0.5-0.20210317001247-091c1fd34afe h1:bw81Ca5HfVEh3KO5pQOzIyYj4ostC+rZiRmIG4xvc5g=
-github.com/aws-controllers-k8s/runtime v0.0.5-0.20210317001247-091c1fd34afe/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
-github.com/aws-controllers-k8s/runtime v0.0.5 h1:WdcnMNdgagF2MMPQRbDJ5OEzMMgHraCJqvvFj4Sx/5g=
-github.com/aws-controllers-k8s/runtime v0.0.5/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.2.0 h1:gd0Kq8xGelgkZoNjr8yZbHfpvPA1R+wfMCi1lT4H8x4=
+github.com/aws-controllers-k8s/runtime v0.2.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/cache_parameter_group/descriptor.go
+++ b/pkg/resource/cache_parameter_group/descriptor.go
@@ -16,6 +16,7 @@
 package cache_parameter_group
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,4 +142,22 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+}
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
 }

--- a/pkg/resource/cache_parameter_group/manager.go
+++ b/pkg/resource/cache_parameter_group/manager.go
@@ -35,8 +35,6 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cacheparametergroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cacheparametergroups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -50,9 +48,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -173,7 +171,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/pkg/resource/cache_parameter_group/manager_factory.go
+++ b/pkg/resource/cache_parameter_group/manager_factory.go
@@ -49,7 +49,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -72,6 +72,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return true
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/cache_parameter_group/resource.go
+++ b/pkg/resource/cache_parameter_group/resource.go
@@ -17,11 +17,17 @@ package cache_parameter_group
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
 )
 
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
@@ -66,4 +72,19 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 // Conditions returns the ACK Conditions collection for the AWSResource
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
+}
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.CacheParameterGroupName = identifier.NameOrID
+	return nil
 }

--- a/pkg/resource/cache_parameter_group/sdk.go
+++ b/pkg/resource/cache_parameter_group/sdk.go
@@ -75,15 +75,23 @@ func (rm *resourceManager) sdkFind(
 		}
 		if elem.CacheParameterGroupFamily != nil {
 			ko.Spec.CacheParameterGroupFamily = elem.CacheParameterGroupFamily
+		} else {
+			ko.Spec.CacheParameterGroupFamily = nil
 		}
 		if elem.CacheParameterGroupName != nil {
 			ko.Spec.CacheParameterGroupName = elem.CacheParameterGroupName
+		} else {
+			ko.Spec.CacheParameterGroupName = nil
 		}
 		if elem.Description != nil {
 			ko.Spec.Description = elem.Description
+		} else {
+			ko.Spec.Description = nil
 		}
 		if elem.IsGlobal != nil {
 			ko.Status.IsGlobal = elem.IsGlobal
+		} else {
+			ko.Status.IsGlobal = nil
 		}
 		found = true
 		break
@@ -146,6 +154,8 @@ func (rm *resourceManager) sdkCreate(
 	}
 	if resp.CacheParameterGroup.IsGlobal != nil {
 		ko.Status.IsGlobal = resp.CacheParameterGroup.IsGlobal
+	} else {
+		ko.Status.IsGlobal = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -246,10 +256,13 @@ func (rm *resourceManager) updateConditions(
 
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
+	var recoverableCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
-			break
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
+			recoverableCondition = condition
 		}
 	}
 
@@ -264,11 +277,34 @@ func (rm *resourceManager) updateConditions(
 		awsErr, _ := ackerr.AWSError(err)
 		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
-	} else if terminalCondition != nil {
-		terminalCondition.Status = corev1.ConditionFalse
-		terminalCondition.Message = nil
+	} else {
+		// Clear the terminal condition if no longer present
+		if terminalCondition != nil {
+			terminalCondition.Status = corev1.ConditionFalse
+			terminalCondition.Message = nil
+		}
+		// Handling Recoverable Conditions
+		if err != nil {
+			if recoverableCondition == nil {
+				// Add a new Condition containing a non-terminal error
+				recoverableCondition = &ackv1alpha1.Condition{
+					Type: ackv1alpha1.ConditionTypeRecoverable,
+				}
+				ko.Status.Conditions = append(ko.Status.Conditions, recoverableCondition)
+			}
+			recoverableCondition.Status = corev1.ConditionTrue
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage := err.Error()
+			if awsErr != nil {
+				errorMessage = awsErr.Message()
+			}
+			recoverableCondition.Message = &errorMessage
+		} else if recoverableCondition != nil {
+			recoverableCondition.Status = corev1.ConditionFalse
+			recoverableCondition.Message = nil
+		}
 	}
-	if terminalCondition != nil {
+	if terminalCondition != nil || recoverableCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/cache_subnet_group/descriptor.go
+++ b/pkg/resource/cache_subnet_group/descriptor.go
@@ -16,6 +16,7 @@
 package cache_subnet_group
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,4 +142,22 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+}
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
 }

--- a/pkg/resource/cache_subnet_group/manager.go
+++ b/pkg/resource/cache_subnet_group/manager.go
@@ -35,8 +35,6 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cachesubnetgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cachesubnetgroups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -50,9 +48,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -173,7 +171,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/pkg/resource/cache_subnet_group/manager_factory.go
+++ b/pkg/resource/cache_subnet_group/manager_factory.go
@@ -49,7 +49,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -72,6 +72,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return true
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/cache_subnet_group/resource.go
+++ b/pkg/resource/cache_subnet_group/resource.go
@@ -17,11 +17,17 @@ package cache_subnet_group
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
 )
 
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
@@ -66,4 +72,19 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 // Conditions returns the ACK Conditions collection for the AWSResource
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
+}
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.CacheSubnetGroupName = identifier.NameOrID
+	return nil
 }

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -75,9 +75,13 @@ func (rm *resourceManager) sdkFind(
 		}
 		if elem.CacheSubnetGroupDescription != nil {
 			ko.Spec.CacheSubnetGroupDescription = elem.CacheSubnetGroupDescription
+		} else {
+			ko.Spec.CacheSubnetGroupDescription = nil
 		}
 		if elem.CacheSubnetGroupName != nil {
 			ko.Spec.CacheSubnetGroupName = elem.CacheSubnetGroupName
+		} else {
+			ko.Spec.CacheSubnetGroupName = nil
 		}
 		if elem.Subnets != nil {
 			f3 := []*svcapitypes.Subnet{}
@@ -103,9 +107,13 @@ func (rm *resourceManager) sdkFind(
 				f3 = append(f3, f3elem)
 			}
 			ko.Status.Subnets = f3
+		} else {
+			ko.Status.Subnets = nil
 		}
 		if elem.VpcId != nil {
 			ko.Status.VPCID = elem.VpcId
+		} else {
+			ko.Status.VPCID = nil
 		}
 		found = true
 		break
@@ -190,9 +198,13 @@ func (rm *resourceManager) sdkCreate(
 			f3 = append(f3, f3elem)
 		}
 		ko.Status.Subnets = f3
+	} else {
+		ko.Status.Subnets = nil
 	}
 	if resp.CacheSubnetGroup.VpcId != nil {
 		ko.Status.VPCID = resp.CacheSubnetGroup.VpcId
+	} else {
+		ko.Status.VPCID = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -281,9 +293,13 @@ func (rm *resourceManager) sdkUpdate(
 			f3 = append(f3, f3elem)
 		}
 		ko.Status.Subnets = f3
+	} else {
+		ko.Status.Subnets = nil
 	}
 	if resp.CacheSubnetGroup.VpcId != nil {
 		ko.Status.VPCID = resp.CacheSubnetGroup.VpcId
+	} else {
+		ko.Status.VPCID = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -373,10 +389,13 @@ func (rm *resourceManager) updateConditions(
 
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
+	var recoverableCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
-			break
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
+			recoverableCondition = condition
 		}
 	}
 
@@ -391,11 +410,34 @@ func (rm *resourceManager) updateConditions(
 		awsErr, _ := ackerr.AWSError(err)
 		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
-	} else if terminalCondition != nil {
-		terminalCondition.Status = corev1.ConditionFalse
-		terminalCondition.Message = nil
+	} else {
+		// Clear the terminal condition if no longer present
+		if terminalCondition != nil {
+			terminalCondition.Status = corev1.ConditionFalse
+			terminalCondition.Message = nil
+		}
+		// Handling Recoverable Conditions
+		if err != nil {
+			if recoverableCondition == nil {
+				// Add a new Condition containing a non-terminal error
+				recoverableCondition = &ackv1alpha1.Condition{
+					Type: ackv1alpha1.ConditionTypeRecoverable,
+				}
+				ko.Status.Conditions = append(ko.Status.Conditions, recoverableCondition)
+			}
+			recoverableCondition.Status = corev1.ConditionTrue
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage := err.Error()
+			if awsErr != nil {
+				errorMessage = awsErr.Message()
+			}
+			recoverableCondition.Message = &errorMessage
+		} else if recoverableCondition != nil {
+			recoverableCondition.Status = corev1.ConditionFalse
+			recoverableCondition.Message = nil
+		}
 	}
-	if terminalCondition != nil {
+	if terminalCondition != nil || recoverableCondition != nil {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/registry.go
+++ b/pkg/resource/registry.go
@@ -20,6 +20,11 @@ import (
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=services.k8s.aws,resources=adoptedresources/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+
 var (
 	reg = ackrt.NewRegistry()
 )

--- a/pkg/resource/replication_group/custom_update_api.go
+++ b/pkg/resource/replication_group/custom_update_api.go
@@ -716,7 +716,7 @@ from the latest observed engine version. Inputs:
 desired: the resource representing the desired state
 latestCacheCluster: a CacheCluster object representing one cache node in the replication group, which
 	reveals the currently used engine version for the entire replication group
- */
+*/
 func (rm *resourceManager) engineVersionsDiffer(
 	desired *resource,
 	latestCacheCluster *svcsdk.CacheCluster,

--- a/pkg/resource/replication_group/descriptor.go
+++ b/pkg/resource/replication_group/descriptor.go
@@ -16,6 +16,7 @@
 package replication_group
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,4 +142,22 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+}
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
 }

--- a/pkg/resource/replication_group/manager.go
+++ b/pkg/resource/replication_group/manager.go
@@ -35,8 +35,6 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=replicationgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=replicationgroups/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -50,9 +48,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -173,7 +171,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/pkg/resource/replication_group/manager_factory.go
+++ b/pkg/resource/replication_group/manager_factory.go
@@ -49,7 +49,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -72,6 +72,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return true
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/replication_group/manager_test_suite_test.go
+++ b/pkg/resource/replication_group/manager_test_suite_test.go
@@ -96,5 +96,12 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	ac := a.(*resource)
 	bc := b.(*resource)
 	opts := []cmp.Option{cmpopts.EquateEmpty()}
-	return cmp.Equal(ac.ko.Status, bc.ko.Status, opts...)
+
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		return true
+	} else {
+		fmt.Printf("Difference (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		return false
+	}
 }

--- a/pkg/resource/replication_group/resource.go
+++ b/pkg/resource/replication_group/resource.go
@@ -17,11 +17,17 @@ package replication_group
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
 )
 
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
@@ -66,4 +72,19 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 // Conditions returns the ACK Conditions collection for the AWSResource
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
+}
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.ReplicationGroupID = identifier.NameOrID
+	return nil
 }

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -75,21 +75,33 @@ func (rm *resourceManager) sdkFind(
 		}
 		if elem.AtRestEncryptionEnabled != nil {
 			ko.Spec.AtRestEncryptionEnabled = elem.AtRestEncryptionEnabled
+		} else {
+			ko.Spec.AtRestEncryptionEnabled = nil
 		}
 		if elem.AuthTokenEnabled != nil {
 			ko.Status.AuthTokenEnabled = elem.AuthTokenEnabled
+		} else {
+			ko.Status.AuthTokenEnabled = nil
 		}
 		if elem.AuthTokenLastModifiedDate != nil {
 			ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*elem.AuthTokenLastModifiedDate}
+		} else {
+			ko.Status.AuthTokenLastModifiedDate = nil
 		}
 		if elem.AutomaticFailover != nil {
 			ko.Status.AutomaticFailover = elem.AutomaticFailover
+		} else {
+			ko.Status.AutomaticFailover = nil
 		}
 		if elem.CacheNodeType != nil {
 			ko.Spec.CacheNodeType = elem.CacheNodeType
+		} else {
+			ko.Spec.CacheNodeType = nil
 		}
 		if elem.ClusterEnabled != nil {
 			ko.Status.ClusterEnabled = elem.ClusterEnabled
+		} else {
+			ko.Status.ClusterEnabled = nil
 		}
 		if elem.ConfigurationEndpoint != nil {
 			f7 := &svcapitypes.Endpoint{}
@@ -100,9 +112,13 @@ func (rm *resourceManager) sdkFind(
 				f7.Port = elem.ConfigurationEndpoint.Port
 			}
 			ko.Status.ConfigurationEndpoint = f7
+		} else {
+			ko.Status.ConfigurationEndpoint = nil
 		}
 		if elem.Description != nil {
 			ko.Status.Description = elem.Description
+		} else {
+			ko.Status.Description = nil
 		}
 		if elem.GlobalReplicationGroupInfo != nil {
 			f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -113,9 +129,13 @@ func (rm *resourceManager) sdkFind(
 				f9.GlobalReplicationGroupMemberRole = elem.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 			}
 			ko.Status.GlobalReplicationGroupInfo = f9
+		} else {
+			ko.Status.GlobalReplicationGroupInfo = nil
 		}
 		if elem.KmsKeyId != nil {
 			ko.Spec.KMSKeyID = elem.KmsKeyId
+		} else {
+			ko.Spec.KMSKeyID = nil
 		}
 		if elem.MemberClusters != nil {
 			f11 := []*string{}
@@ -125,6 +145,8 @@ func (rm *resourceManager) sdkFind(
 				f11 = append(f11, &f11elem)
 			}
 			ko.Status.MemberClusters = f11
+		} else {
+			ko.Status.MemberClusters = nil
 		}
 		if elem.MemberClustersOutpostArns != nil {
 			f12 := []*string{}
@@ -134,9 +156,13 @@ func (rm *resourceManager) sdkFind(
 				f12 = append(f12, &f12elem)
 			}
 			ko.Status.MemberClustersOutpostARNs = f12
+		} else {
+			ko.Status.MemberClustersOutpostARNs = nil
 		}
 		if elem.MultiAZ != nil {
 			ko.Status.MultiAZ = elem.MultiAZ
+		} else {
+			ko.Status.MultiAZ = nil
 		}
 		if elem.NodeGroups != nil {
 			f14 := []*svcapitypes.NodeGroup{}
@@ -207,6 +233,8 @@ func (rm *resourceManager) sdkFind(
 				f14 = append(f14, f14elem)
 			}
 			ko.Status.NodeGroups = f14
+		} else {
+			ko.Status.NodeGroups = nil
 		}
 		if elem.PendingModifiedValues != nil {
 			f15 := &svcapitypes.ReplicationGroupPendingModifiedValues{}
@@ -253,24 +281,38 @@ func (rm *resourceManager) sdkFind(
 				f15.UserGroups = f15f4
 			}
 			ko.Status.PendingModifiedValues = f15
+		} else {
+			ko.Status.PendingModifiedValues = nil
 		}
 		if elem.ReplicationGroupId != nil {
 			ko.Spec.ReplicationGroupID = elem.ReplicationGroupId
+		} else {
+			ko.Spec.ReplicationGroupID = nil
 		}
 		if elem.SnapshotRetentionLimit != nil {
 			ko.Spec.SnapshotRetentionLimit = elem.SnapshotRetentionLimit
+		} else {
+			ko.Spec.SnapshotRetentionLimit = nil
 		}
 		if elem.SnapshotWindow != nil {
 			ko.Spec.SnapshotWindow = elem.SnapshotWindow
+		} else {
+			ko.Spec.SnapshotWindow = nil
 		}
 		if elem.SnapshottingClusterId != nil {
 			ko.Status.SnapshottingClusterID = elem.SnapshottingClusterId
+		} else {
+			ko.Status.SnapshottingClusterID = nil
 		}
 		if elem.Status != nil {
 			ko.Status.Status = elem.Status
+		} else {
+			ko.Status.Status = nil
 		}
 		if elem.TransitEncryptionEnabled != nil {
 			ko.Spec.TransitEncryptionEnabled = elem.TransitEncryptionEnabled
+		} else {
+			ko.Spec.TransitEncryptionEnabled = nil
 		}
 		if elem.UserGroupIds != nil {
 			f22 := []*string{}
@@ -280,6 +322,8 @@ func (rm *resourceManager) sdkFind(
 				f22 = append(f22, &f22elem)
 			}
 			ko.Spec.UserGroupIDs = f22
+		} else {
+			ko.Spec.UserGroupIDs = nil
 		}
 		found = true
 		break
@@ -342,15 +386,23 @@ func (rm *resourceManager) sdkCreate(
 	}
 	if resp.ReplicationGroup.AuthTokenEnabled != nil {
 		ko.Status.AuthTokenEnabled = resp.ReplicationGroup.AuthTokenEnabled
+	} else {
+		ko.Status.AuthTokenEnabled = nil
 	}
 	if resp.ReplicationGroup.AuthTokenLastModifiedDate != nil {
 		ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*resp.ReplicationGroup.AuthTokenLastModifiedDate}
+	} else {
+		ko.Status.AuthTokenLastModifiedDate = nil
 	}
 	if resp.ReplicationGroup.AutomaticFailover != nil {
 		ko.Status.AutomaticFailover = resp.ReplicationGroup.AutomaticFailover
+	} else {
+		ko.Status.AutomaticFailover = nil
 	}
 	if resp.ReplicationGroup.ClusterEnabled != nil {
 		ko.Status.ClusterEnabled = resp.ReplicationGroup.ClusterEnabled
+	} else {
+		ko.Status.ClusterEnabled = nil
 	}
 	if resp.ReplicationGroup.ConfigurationEndpoint != nil {
 		f7 := &svcapitypes.Endpoint{}
@@ -361,9 +413,13 @@ func (rm *resourceManager) sdkCreate(
 			f7.Port = resp.ReplicationGroup.ConfigurationEndpoint.Port
 		}
 		ko.Status.ConfigurationEndpoint = f7
+	} else {
+		ko.Status.ConfigurationEndpoint = nil
 	}
 	if resp.ReplicationGroup.Description != nil {
 		ko.Status.Description = resp.ReplicationGroup.Description
+	} else {
+		ko.Status.Description = nil
 	}
 	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
 		f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -374,6 +430,8 @@ func (rm *resourceManager) sdkCreate(
 			f9.GlobalReplicationGroupMemberRole = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 		}
 		ko.Status.GlobalReplicationGroupInfo = f9
+	} else {
+		ko.Status.GlobalReplicationGroupInfo = nil
 	}
 	if resp.ReplicationGroup.MemberClusters != nil {
 		f11 := []*string{}
@@ -383,6 +441,8 @@ func (rm *resourceManager) sdkCreate(
 			f11 = append(f11, &f11elem)
 		}
 		ko.Status.MemberClusters = f11
+	} else {
+		ko.Status.MemberClusters = nil
 	}
 	if resp.ReplicationGroup.MemberClustersOutpostArns != nil {
 		f12 := []*string{}
@@ -392,9 +452,13 @@ func (rm *resourceManager) sdkCreate(
 			f12 = append(f12, &f12elem)
 		}
 		ko.Status.MemberClustersOutpostARNs = f12
+	} else {
+		ko.Status.MemberClustersOutpostARNs = nil
 	}
 	if resp.ReplicationGroup.MultiAZ != nil {
 		ko.Status.MultiAZ = resp.ReplicationGroup.MultiAZ
+	} else {
+		ko.Status.MultiAZ = nil
 	}
 	if resp.ReplicationGroup.NodeGroups != nil {
 		f14 := []*svcapitypes.NodeGroup{}
@@ -465,6 +529,8 @@ func (rm *resourceManager) sdkCreate(
 			f14 = append(f14, f14elem)
 		}
 		ko.Status.NodeGroups = f14
+	} else {
+		ko.Status.NodeGroups = nil
 	}
 	if resp.ReplicationGroup.PendingModifiedValues != nil {
 		f15 := &svcapitypes.ReplicationGroupPendingModifiedValues{}
@@ -511,12 +577,18 @@ func (rm *resourceManager) sdkCreate(
 			f15.UserGroups = f15f4
 		}
 		ko.Status.PendingModifiedValues = f15
+	} else {
+		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.ReplicationGroup.SnapshottingClusterId != nil {
 		ko.Status.SnapshottingClusterID = resp.ReplicationGroup.SnapshottingClusterId
+	} else {
+		ko.Status.SnapshottingClusterID = nil
 	}
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
+	} else {
+		ko.Status.Status = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -757,15 +829,23 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	if resp.ReplicationGroup.AuthTokenEnabled != nil {
 		ko.Status.AuthTokenEnabled = resp.ReplicationGroup.AuthTokenEnabled
+	} else {
+		ko.Status.AuthTokenEnabled = nil
 	}
 	if resp.ReplicationGroup.AuthTokenLastModifiedDate != nil {
 		ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*resp.ReplicationGroup.AuthTokenLastModifiedDate}
+	} else {
+		ko.Status.AuthTokenLastModifiedDate = nil
 	}
 	if resp.ReplicationGroup.AutomaticFailover != nil {
 		ko.Status.AutomaticFailover = resp.ReplicationGroup.AutomaticFailover
+	} else {
+		ko.Status.AutomaticFailover = nil
 	}
 	if resp.ReplicationGroup.ClusterEnabled != nil {
 		ko.Status.ClusterEnabled = resp.ReplicationGroup.ClusterEnabled
+	} else {
+		ko.Status.ClusterEnabled = nil
 	}
 	if resp.ReplicationGroup.ConfigurationEndpoint != nil {
 		f7 := &svcapitypes.Endpoint{}
@@ -776,9 +856,13 @@ func (rm *resourceManager) sdkUpdate(
 			f7.Port = resp.ReplicationGroup.ConfigurationEndpoint.Port
 		}
 		ko.Status.ConfigurationEndpoint = f7
+	} else {
+		ko.Status.ConfigurationEndpoint = nil
 	}
 	if resp.ReplicationGroup.Description != nil {
 		ko.Status.Description = resp.ReplicationGroup.Description
+	} else {
+		ko.Status.Description = nil
 	}
 	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
 		f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -789,6 +873,8 @@ func (rm *resourceManager) sdkUpdate(
 			f9.GlobalReplicationGroupMemberRole = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 		}
 		ko.Status.GlobalReplicationGroupInfo = f9
+	} else {
+		ko.Status.GlobalReplicationGroupInfo = nil
 	}
 	if resp.ReplicationGroup.MemberClusters != nil {
 		f11 := []*string{}
@@ -798,6 +884,8 @@ func (rm *resourceManager) sdkUpdate(
 			f11 = append(f11, &f11elem)
 		}
 		ko.Status.MemberClusters = f11
+	} else {
+		ko.Status.MemberClusters = nil
 	}
 	if resp.ReplicationGroup.MemberClustersOutpostArns != nil {
 		f12 := []*string{}
@@ -807,9 +895,13 @@ func (rm *resourceManager) sdkUpdate(
 			f12 = append(f12, &f12elem)
 		}
 		ko.Status.MemberClustersOutpostARNs = f12
+	} else {
+		ko.Status.MemberClustersOutpostARNs = nil
 	}
 	if resp.ReplicationGroup.MultiAZ != nil {
 		ko.Status.MultiAZ = resp.ReplicationGroup.MultiAZ
+	} else {
+		ko.Status.MultiAZ = nil
 	}
 	if resp.ReplicationGroup.NodeGroups != nil {
 		f14 := []*svcapitypes.NodeGroup{}
@@ -880,6 +972,8 @@ func (rm *resourceManager) sdkUpdate(
 			f14 = append(f14, f14elem)
 		}
 		ko.Status.NodeGroups = f14
+	} else {
+		ko.Status.NodeGroups = nil
 	}
 	if resp.ReplicationGroup.PendingModifiedValues != nil {
 		f15 := &svcapitypes.ReplicationGroupPendingModifiedValues{}
@@ -926,12 +1020,18 @@ func (rm *resourceManager) sdkUpdate(
 			f15.UserGroups = f15f4
 		}
 		ko.Status.PendingModifiedValues = f15
+	} else {
+		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.ReplicationGroup.SnapshottingClusterId != nil {
 		ko.Status.SnapshottingClusterID = resp.ReplicationGroup.SnapshottingClusterId
+	} else {
+		ko.Status.SnapshottingClusterID = nil
 	}
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
+	} else {
+		ko.Status.Status = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -1070,10 +1170,13 @@ func (rm *resourceManager) updateConditions(
 
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
+	var recoverableCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
-			break
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
+			recoverableCondition = condition
 		}
 	}
 
@@ -1088,13 +1191,36 @@ func (rm *resourceManager) updateConditions(
 		awsErr, _ := ackerr.AWSError(err)
 		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
-	} else if terminalCondition != nil {
-		terminalCondition.Status = corev1.ConditionFalse
-		terminalCondition.Message = nil
+	} else {
+		// Clear the terminal condition if no longer present
+		if terminalCondition != nil {
+			terminalCondition.Status = corev1.ConditionFalse
+			terminalCondition.Message = nil
+		}
+		// Handling Recoverable Conditions
+		if err != nil {
+			if recoverableCondition == nil {
+				// Add a new Condition containing a non-terminal error
+				recoverableCondition = &ackv1alpha1.Condition{
+					Type: ackv1alpha1.ConditionTypeRecoverable,
+				}
+				ko.Status.Conditions = append(ko.Status.Conditions, recoverableCondition)
+			}
+			recoverableCondition.Status = corev1.ConditionTrue
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage := err.Error()
+			if awsErr != nil {
+				errorMessage = awsErr.Message()
+			}
+			recoverableCondition.Message = &errorMessage
+		} else if recoverableCondition != nil {
+			recoverableCondition.Status = corev1.ConditionFalse
+			recoverableCondition.Message = nil
+		}
 	}
 	// custom update conditions
 	customUpdate := rm.CustomUpdateConditions(ko, r, err)
-	if terminalCondition != nil || customUpdate {
+	if terminalCondition != nil || recoverableCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed.yaml
@@ -2,12 +2,16 @@ apiVersion: elasticache.services.k8s.aws/v1alpha1
 kind: ReplicationGroup
 # omitted metadata
 spec:
+  atRestEncryptionEnabled: false
   cacheNodeType: cache.t3.micro
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
   replicationGroupDescription: cluster-mode disabled RG
   replicationGroupID: rg-cmd
+  snapshotRetentionLimit: 0
+  snapshotWindow: "10:00-11:00"
+  transitEncryptionEnabled: false
 status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
@@ -12,7 +12,6 @@ status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
     ownerAccountID: ""
-  authTokenEnabled: false
   automaticFailover: disabled
   clusterEnabled: false
   conditions:

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
@@ -3,7 +3,6 @@ kind: ReplicationGroup
 # omitted metadata
 spec:
   cacheNodeType: cache.t3.micro
-  cacheSubnetGroupName: default
   engine: redis
   nodeGroupConfiguration:
     - nodeGroupID: "1111"

--- a/pkg/resource/snapshot/descriptor.go
+++ b/pkg/resource/snapshot/descriptor.go
@@ -16,6 +16,7 @@
 package snapshot
 
 import (
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -141,4 +142,22 @@ func (d *resourceDescriptor) MarkUnmanaged(
 		panic("nil RuntimeMetaObject in AWSResource")
 	}
 	k8sctrlutil.RemoveFinalizer(obj, finalizerString)
+}
+
+// MarkAdopted places descriptors on the custom resource that indicate the
+// resource was not created from within ACK.
+func (d *resourceDescriptor) MarkAdopted(
+	res acktypes.AWSResource,
+) {
+	obj := res.RuntimeMetaObject()
+	if obj == nil {
+		// Should not happen. If it does, there is a bug in the code
+		panic("nil RuntimeMetaObject in AWSResource")
+	}
+	curr := obj.GetAnnotations()
+	if curr == nil {
+		curr = make(map[string]string)
+	}
+	curr[ackv1alpha1.AnnotationAdopted] = "true"
+	obj.SetAnnotations(curr)
 }

--- a/pkg/resource/snapshot/manager.go
+++ b/pkg/resource/snapshot/manager.go
@@ -35,8 +35,6 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=snapshots,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=snapshots/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -50,9 +48,9 @@ type resourceManager struct {
 	// metrics contains a collection of Prometheus metric objects that the
 	// service controller and its reconcilers track
 	metrics *ackmetrics.Metrics
-	// rr is the AWSResourceReconciler which can be used for various utility
+	// rr is the Reconciler which can be used for various utility
 	// functions such as querying for Secret values given a SecretReference
-	rr acktypes.AWSResourceReconciler
+	rr acktypes.Reconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -173,7 +171,7 @@ func newResourceManager(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,

--- a/pkg/resource/snapshot/manager_factory.go
+++ b/pkg/resource/snapshot/manager_factory.go
@@ -49,7 +49,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
-	rr acktypes.AWSResourceReconciler,
+	rr acktypes.Reconciler,
 	sess *session.Session,
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
@@ -72,6 +72,11 @@ func (f *resourceManagerFactory) ManagerFor(
 	}
 	f.rmCache[rmId] = rm
 	return rm, nil
+}
+
+// IsAdoptable returns true if the resource is able to be adopted
+func (f *resourceManagerFactory) IsAdoptable() bool {
+	return true
 }
 
 func newResourceManagerFactory() *resourceManagerFactory {

--- a/pkg/resource/snapshot/resource.go
+++ b/pkg/resource/snapshot/resource.go
@@ -17,11 +17,17 @@ package snapshot
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerrors "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
+)
+
+// Hack to avoid import errors during build...
+var (
+	_ = &ackerrors.MissingNameIdentifier
 )
 
 // resource implements the `aws-controller-k8s/runtime/pkg/types.AWSResource`
@@ -66,4 +72,19 @@ func (r *resource) RuntimeMetaObject() acktypes.RuntimeMetaObject {
 // Conditions returns the ACK Conditions collection for the AWSResource
 func (r *resource) Conditions() []*ackv1alpha1.Condition {
 	return r.ko.Status.Conditions
+}
+
+// SetObjectMeta sets the ObjectMeta field for the resource
+func (r *resource) SetObjectMeta(meta metav1.ObjectMeta) {
+	r.ko.ObjectMeta = meta
+}
+
+// SetIdentifiers sets the Spec or Status field that is referenced as the unique
+// resource identifier
+func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error {
+	if identifier.NameOrID == nil {
+		return ackerrors.MissingNameIdentifier
+	}
+	r.ko.Spec.SnapshotName = identifier.NameOrID
+	return nil
 }

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -75,33 +75,53 @@ func (rm *resourceManager) sdkFind(
 		}
 		if elem.AutoMinorVersionUpgrade != nil {
 			ko.Status.AutoMinorVersionUpgrade = elem.AutoMinorVersionUpgrade
+		} else {
+			ko.Status.AutoMinorVersionUpgrade = nil
 		}
 		if elem.AutomaticFailover != nil {
 			ko.Status.AutomaticFailover = elem.AutomaticFailover
+		} else {
+			ko.Status.AutomaticFailover = nil
 		}
 		if elem.CacheClusterCreateTime != nil {
 			ko.Status.CacheClusterCreateTime = &metav1.Time{*elem.CacheClusterCreateTime}
+		} else {
+			ko.Status.CacheClusterCreateTime = nil
 		}
 		if elem.CacheClusterId != nil {
 			ko.Spec.CacheClusterID = elem.CacheClusterId
+		} else {
+			ko.Spec.CacheClusterID = nil
 		}
 		if elem.CacheNodeType != nil {
 			ko.Status.CacheNodeType = elem.CacheNodeType
+		} else {
+			ko.Status.CacheNodeType = nil
 		}
 		if elem.CacheParameterGroupName != nil {
 			ko.Status.CacheParameterGroupName = elem.CacheParameterGroupName
+		} else {
+			ko.Status.CacheParameterGroupName = nil
 		}
 		if elem.CacheSubnetGroupName != nil {
 			ko.Status.CacheSubnetGroupName = elem.CacheSubnetGroupName
+		} else {
+			ko.Status.CacheSubnetGroupName = nil
 		}
 		if elem.Engine != nil {
 			ko.Status.Engine = elem.Engine
+		} else {
+			ko.Status.Engine = nil
 		}
 		if elem.EngineVersion != nil {
 			ko.Status.EngineVersion = elem.EngineVersion
+		} else {
+			ko.Status.EngineVersion = nil
 		}
 		if elem.KmsKeyId != nil {
 			ko.Spec.KMSKeyID = elem.KmsKeyId
+		} else {
+			ko.Spec.KMSKeyID = nil
 		}
 		if elem.NodeSnapshots != nil {
 			f11 := []*svcapitypes.NodeSnapshot{}
@@ -165,51 +185,83 @@ func (rm *resourceManager) sdkFind(
 				f11 = append(f11, f11elem)
 			}
 			ko.Status.NodeSnapshots = f11
+		} else {
+			ko.Status.NodeSnapshots = nil
 		}
 		if elem.NumCacheNodes != nil {
 			ko.Status.NumCacheNodes = elem.NumCacheNodes
+		} else {
+			ko.Status.NumCacheNodes = nil
 		}
 		if elem.NumNodeGroups != nil {
 			ko.Status.NumNodeGroups = elem.NumNodeGroups
+		} else {
+			ko.Status.NumNodeGroups = nil
 		}
 		if elem.Port != nil {
 			ko.Status.Port = elem.Port
+		} else {
+			ko.Status.Port = nil
 		}
 		if elem.PreferredAvailabilityZone != nil {
 			ko.Status.PreferredAvailabilityZone = elem.PreferredAvailabilityZone
+		} else {
+			ko.Status.PreferredAvailabilityZone = nil
 		}
 		if elem.PreferredMaintenanceWindow != nil {
 			ko.Status.PreferredMaintenanceWindow = elem.PreferredMaintenanceWindow
+		} else {
+			ko.Status.PreferredMaintenanceWindow = nil
 		}
 		if elem.PreferredOutpostArn != nil {
 			ko.Status.PreferredOutpostARN = elem.PreferredOutpostArn
+		} else {
+			ko.Status.PreferredOutpostARN = nil
 		}
 		if elem.ReplicationGroupDescription != nil {
 			ko.Status.ReplicationGroupDescription = elem.ReplicationGroupDescription
+		} else {
+			ko.Status.ReplicationGroupDescription = nil
 		}
 		if elem.ReplicationGroupId != nil {
 			ko.Spec.ReplicationGroupID = elem.ReplicationGroupId
+		} else {
+			ko.Spec.ReplicationGroupID = nil
 		}
 		if elem.SnapshotName != nil {
 			ko.Spec.SnapshotName = elem.SnapshotName
+		} else {
+			ko.Spec.SnapshotName = nil
 		}
 		if elem.SnapshotRetentionLimit != nil {
 			ko.Status.SnapshotRetentionLimit = elem.SnapshotRetentionLimit
+		} else {
+			ko.Status.SnapshotRetentionLimit = nil
 		}
 		if elem.SnapshotSource != nil {
 			ko.Status.SnapshotSource = elem.SnapshotSource
+		} else {
+			ko.Status.SnapshotSource = nil
 		}
 		if elem.SnapshotStatus != nil {
 			ko.Status.SnapshotStatus = elem.SnapshotStatus
+		} else {
+			ko.Status.SnapshotStatus = nil
 		}
 		if elem.SnapshotWindow != nil {
 			ko.Status.SnapshotWindow = elem.SnapshotWindow
+		} else {
+			ko.Status.SnapshotWindow = nil
 		}
 		if elem.TopicArn != nil {
 			ko.Status.TopicARN = elem.TopicArn
+		} else {
+			ko.Status.TopicARN = nil
 		}
 		if elem.VpcId != nil {
 			ko.Status.VPCID = elem.VpcId
+		} else {
+			ko.Status.VPCID = nil
 		}
 		found = true
 		break
@@ -276,27 +328,43 @@ func (rm *resourceManager) sdkCreate(
 	}
 	if resp.Snapshot.AutoMinorVersionUpgrade != nil {
 		ko.Status.AutoMinorVersionUpgrade = resp.Snapshot.AutoMinorVersionUpgrade
+	} else {
+		ko.Status.AutoMinorVersionUpgrade = nil
 	}
 	if resp.Snapshot.AutomaticFailover != nil {
 		ko.Status.AutomaticFailover = resp.Snapshot.AutomaticFailover
+	} else {
+		ko.Status.AutomaticFailover = nil
 	}
 	if resp.Snapshot.CacheClusterCreateTime != nil {
 		ko.Status.CacheClusterCreateTime = &metav1.Time{*resp.Snapshot.CacheClusterCreateTime}
+	} else {
+		ko.Status.CacheClusterCreateTime = nil
 	}
 	if resp.Snapshot.CacheNodeType != nil {
 		ko.Status.CacheNodeType = resp.Snapshot.CacheNodeType
+	} else {
+		ko.Status.CacheNodeType = nil
 	}
 	if resp.Snapshot.CacheParameterGroupName != nil {
 		ko.Status.CacheParameterGroupName = resp.Snapshot.CacheParameterGroupName
+	} else {
+		ko.Status.CacheParameterGroupName = nil
 	}
 	if resp.Snapshot.CacheSubnetGroupName != nil {
 		ko.Status.CacheSubnetGroupName = resp.Snapshot.CacheSubnetGroupName
+	} else {
+		ko.Status.CacheSubnetGroupName = nil
 	}
 	if resp.Snapshot.Engine != nil {
 		ko.Status.Engine = resp.Snapshot.Engine
+	} else {
+		ko.Status.Engine = nil
 	}
 	if resp.Snapshot.EngineVersion != nil {
 		ko.Status.EngineVersion = resp.Snapshot.EngineVersion
+	} else {
+		ko.Status.EngineVersion = nil
 	}
 	if resp.Snapshot.NodeSnapshots != nil {
 		f11 := []*svcapitypes.NodeSnapshot{}
@@ -360,45 +428,73 @@ func (rm *resourceManager) sdkCreate(
 			f11 = append(f11, f11elem)
 		}
 		ko.Status.NodeSnapshots = f11
+	} else {
+		ko.Status.NodeSnapshots = nil
 	}
 	if resp.Snapshot.NumCacheNodes != nil {
 		ko.Status.NumCacheNodes = resp.Snapshot.NumCacheNodes
+	} else {
+		ko.Status.NumCacheNodes = nil
 	}
 	if resp.Snapshot.NumNodeGroups != nil {
 		ko.Status.NumNodeGroups = resp.Snapshot.NumNodeGroups
+	} else {
+		ko.Status.NumNodeGroups = nil
 	}
 	if resp.Snapshot.Port != nil {
 		ko.Status.Port = resp.Snapshot.Port
+	} else {
+		ko.Status.Port = nil
 	}
 	if resp.Snapshot.PreferredAvailabilityZone != nil {
 		ko.Status.PreferredAvailabilityZone = resp.Snapshot.PreferredAvailabilityZone
+	} else {
+		ko.Status.PreferredAvailabilityZone = nil
 	}
 	if resp.Snapshot.PreferredMaintenanceWindow != nil {
 		ko.Status.PreferredMaintenanceWindow = resp.Snapshot.PreferredMaintenanceWindow
+	} else {
+		ko.Status.PreferredMaintenanceWindow = nil
 	}
 	if resp.Snapshot.PreferredOutpostArn != nil {
 		ko.Status.PreferredOutpostARN = resp.Snapshot.PreferredOutpostArn
+	} else {
+		ko.Status.PreferredOutpostARN = nil
 	}
 	if resp.Snapshot.ReplicationGroupDescription != nil {
 		ko.Status.ReplicationGroupDescription = resp.Snapshot.ReplicationGroupDescription
+	} else {
+		ko.Status.ReplicationGroupDescription = nil
 	}
 	if resp.Snapshot.SnapshotRetentionLimit != nil {
 		ko.Status.SnapshotRetentionLimit = resp.Snapshot.SnapshotRetentionLimit
+	} else {
+		ko.Status.SnapshotRetentionLimit = nil
 	}
 	if resp.Snapshot.SnapshotSource != nil {
 		ko.Status.SnapshotSource = resp.Snapshot.SnapshotSource
+	} else {
+		ko.Status.SnapshotSource = nil
 	}
 	if resp.Snapshot.SnapshotStatus != nil {
 		ko.Status.SnapshotStatus = resp.Snapshot.SnapshotStatus
+	} else {
+		ko.Status.SnapshotStatus = nil
 	}
 	if resp.Snapshot.SnapshotWindow != nil {
 		ko.Status.SnapshotWindow = resp.Snapshot.SnapshotWindow
+	} else {
+		ko.Status.SnapshotWindow = nil
 	}
 	if resp.Snapshot.TopicArn != nil {
 		ko.Status.TopicARN = resp.Snapshot.TopicArn
+	} else {
+		ko.Status.TopicARN = nil
 	}
 	if resp.Snapshot.VpcId != nil {
 		ko.Status.VPCID = resp.Snapshot.VpcId
+	} else {
+		ko.Status.VPCID = nil
 	}
 
 	rm.setStatusDefaults(ko)
@@ -502,10 +598,13 @@ func (rm *resourceManager) updateConditions(
 
 	// Terminal condition
 	var terminalCondition *ackv1alpha1.Condition = nil
+	var recoverableCondition *ackv1alpha1.Condition = nil
 	for _, condition := range ko.Status.Conditions {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
 			terminalCondition = condition
-			break
+		}
+		if condition.Type == ackv1alpha1.ConditionTypeRecoverable {
+			recoverableCondition = condition
 		}
 	}
 
@@ -520,13 +619,36 @@ func (rm *resourceManager) updateConditions(
 		awsErr, _ := ackerr.AWSError(err)
 		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
-	} else if terminalCondition != nil {
-		terminalCondition.Status = corev1.ConditionFalse
-		terminalCondition.Message = nil
+	} else {
+		// Clear the terminal condition if no longer present
+		if terminalCondition != nil {
+			terminalCondition.Status = corev1.ConditionFalse
+			terminalCondition.Message = nil
+		}
+		// Handling Recoverable Conditions
+		if err != nil {
+			if recoverableCondition == nil {
+				// Add a new Condition containing a non-terminal error
+				recoverableCondition = &ackv1alpha1.Condition{
+					Type: ackv1alpha1.ConditionTypeRecoverable,
+				}
+				ko.Status.Conditions = append(ko.Status.Conditions, recoverableCondition)
+			}
+			recoverableCondition.Status = corev1.ConditionTrue
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage := err.Error()
+			if awsErr != nil {
+				errorMessage = awsErr.Message()
+			}
+			recoverableCondition.Message = &errorMessage
+		} else if recoverableCondition != nil {
+			recoverableCondition.Status = corev1.ConditionFalse
+			recoverableCondition.Message = nil
+		}
 	}
 	// custom update conditions
 	customUpdate := rm.CustomUpdateConditions(ko, r, err)
-	if terminalCondition != nil || customUpdate {
+	if terminalCondition != nil || recoverableCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/testutil/test_suite_config.go
+++ b/pkg/testutil/test_suite_config.go
@@ -50,15 +50,15 @@ type Fixture struct {
 
 // ServiceAPI represents details about the the service sdk api and fixture path to mock its response
 type ServiceAPI struct {
-	Operation string `json:"operation"`
-	Output    string `json:"output_fixture"`
-	ServiceAPIError  *ServiceAPIError `json:"error,omitempty"`
+	Operation       string           `json:"operation"`
+	Output          string           `json:"output_fixture"`
+	ServiceAPIError *ServiceAPIError `json:"error,omitempty"`
 }
 
 // ServiceAPIError contains the specification for the error of the mock API response
 type ServiceAPIError struct {
 	// Code here is usually the type of fault/error, not the HTTP status code
-	Code string `json:"code"`
+	Code    string `json:"code"`
 	Message string `json:"message"`
 }
 
@@ -67,5 +67,5 @@ type Expect struct {
 	LatestState string `json:"latest_state"`
 	// Error is a string matching the message of the expected error returned from the ResourceManager operation.
 	// Possible errors can be found in runtime/pkg/errors/error.go
-	Error       string `json:"error"`
+	Error string `json:"error"`
 }

--- a/pkg/testutil/test_suite_runner.go
+++ b/pkg/testutil/test_suite_runner.go
@@ -101,16 +101,16 @@ func (runner *TestSuiteRunner) runTestScenario(scenarioName string, fixtureCxt *
 }
 
 /* assertExpectations validates the actual outcome against the expected outcome.
-	There are two components to the expected outcome, corresponding to the return values of the resource manager's CRUD operation:
-		1) the actual return value of type AWSResource ("expect.latest_state" in test_suite.yaml)
-		2) the error ("expect.error" in test_suite.yaml)
-	With each of these components, there are three possibilities in test_suite.yaml, which are interpreted as follows:
-		1) the key does not exist, or was provided with no value: no explicit expectations, don't assert anything
-		2) the key was provided with value "nil": explicit expectation; assert that the error or return value is nil
-		3) the key was provided with value other than "nil": explicit expectation; assert that the value matches the
-			expected value
-	However, if neither expect.latest_state nor error are provided, assertExpectations will fail the test case.
- */
+There are two components to the expected outcome, corresponding to the return values of the resource manager's CRUD operation:
+	1) the actual return value of type AWSResource ("expect.latest_state" in test_suite.yaml)
+	2) the error ("expect.error" in test_suite.yaml)
+With each of these components, there are three possibilities in test_suite.yaml, which are interpreted as follows:
+	1) the key does not exist, or was provided with no value: no explicit expectations, don't assert anything
+	2) the key was provided with value "nil": explicit expectation; assert that the error or return value is nil
+	3) the key was provided with value other than "nil": explicit expectation; assert that the value matches the
+		expected value
+However, if neither expect.latest_state nor error are provided, assertExpectations will fail the test case.
+*/
 func (runner *TestSuiteRunner) assertExpectations(assert *assert.Assertions, expectation *Expect, actual acktypes.AWSResource, err error) {
 	if expectation.LatestState == "" && expectation.Error == "" {
 		fmt.Println("Invalid test case: no expectation given for either latest_state or error")

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -53,5 +53,5 @@ func LoadFromFixture(
 // can be added in the future if needed
 func CreateAWSError(awsError ServiceAPIError) awserr.RequestFailure {
 	error := awserr.New(awsError.Code, awsError.Message, nil)
-	return awserr.NewRequestFailure(error, 0,"")
+	return awserr.NewRequestFailure(error, 0, "")
 }

--- a/pkg/testutil/util_test.go
+++ b/pkg/testutil/util_test.go
@@ -34,5 +34,4 @@ func TestCreateAWSError(t *testing.T) {
 		assert.Equal("ReplicationGroup rg-cmd not found", awsErr.Message())
 	})
 
-
 }

--- a/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
@@ -3,6 +3,8 @@ kind: ReplicationGroup
 metadata:
   name: $RG_ID
 spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
   replicationGroupDescription: test replication group for input field coverage
   replicationGroupID: $RG_ID
   snapshotName: $SNAPSHOT_NAME

--- a/test/e2e/resources/replicationgroup_cmd_update.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_update.yaml
@@ -1,0 +1,13 @@
+# Basic CMD replication group for testing Update behavior
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $RG_ID
+spec:
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  engineVersion: $ENGINE_VERSION
+  numNodeGroups: $NUM_NODE_GROUPS
+  replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: $RG_ID

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -20,22 +20,26 @@ import logging
 from time import sleep
 
 from acktest.resources import random_suffix_name
-from acktest.k8s import resources as k8s
+from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_elasticache_resource
 from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e.util import retrieve_cache_cluster
 
 RESOURCE_PLURAL = "replicationgroups"
 DEFAULT_WAIT_SECS = 30
+
 
 @pytest.fixture(scope="module")
 def rg_deletion_waiter():
     ec = boto3.client("elasticache")
     return ec.get_waiter('replication_group_deleted')
 
+
 # retrieve resources created in the bootstrap step
 @pytest.fixture(scope="module")
 def bootstrap_resources():
     return get_bootstrap_resources()
+
 
 # factory for replication group names
 @pytest.fixture(scope="module")
@@ -44,6 +48,7 @@ def make_rg_name():
         return random_suffix_name(base, 32)
 
     return _make_rg_name
+
 
 # factory for replication groups
 @pytest.fixture(scope="module")
@@ -61,6 +66,7 @@ def make_replication_group():
         return (reference, resource)
 
     return _make_replication_group
+
 
 @pytest.fixture(scope="module")
 def rg_input_coverage(bootstrap_resources, make_rg_name, make_replication_group, rg_deletion_waiter):
@@ -80,11 +86,13 @@ def rg_input_coverage(bootstrap_resources, make_rg_name, make_replication_group,
     sleep(DEFAULT_WAIT_SECS)
     rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"]) #throws exception if wait fails
 
+
 @pytest.fixture(scope="module")
 def first_secret():
     k8s.create_opaque_secret("default", "first", "secret1", "securetoken123456")
     yield
     k8s.delete_secret("default", "first")
+
 
 @pytest.fixture(scope="module")
 def second_secret():
@@ -106,6 +114,7 @@ def rg_auth_token(make_rg_name, make_replication_group, rg_deletion_waiter, firs
     sleep(DEFAULT_WAIT_SECS)
     rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"]) #throws exception if wait fails
 
+
 @pytest.fixture(scope="module")
 def rg_cmd_fromsnapshot(bootstrap_resources, make_rg_name, make_replication_group, rg_deletion_waiter):
     input_dict = {
@@ -114,6 +123,29 @@ def rg_cmd_fromsnapshot(bootstrap_resources, make_rg_name, make_replication_grou
     }
 
     (reference, resource) = make_replication_group("replicationgroup_cmd_fromsnapshot", input_dict, input_dict["RG_ID"])
+    yield (reference, resource)
+
+    # teardown
+    k8s.delete_custom_resource(reference)
+    sleep(DEFAULT_WAIT_SECS)
+    rg_deletion_waiter.wait(ReplicationGroupId=input_dict["RG_ID"])
+
+
+@pytest.fixture(scope="module")
+def rg_cmd_update_input(make_rg_name):
+    return {
+        "RG_ID": make_rg_name("rg-cmd-update"),
+        "ENGINE_VERSION": "5.0.0",
+        "NUM_NODE_GROUPS": "1",
+        "REPLICAS_PER_NODE_GROUP": "1"
+    }
+
+
+@pytest.fixture(scope="module")
+def rg_cmd_update(rg_cmd_update_input, make_replication_group, rg_deletion_waiter):
+    input_dict = rg_cmd_update_input
+
+    (reference, resource) = make_replication_group("replicationgroup_cmd_update", input_dict, input_dict["RG_ID"])
     yield (reference, resource)
 
     # teardown
@@ -132,6 +164,52 @@ class TestReplicationGroup:
     def test_rg_cmd_fromsnapshot(self, rg_cmd_fromsnapshot):
         (reference, _) = rg_cmd_fromsnapshot
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+    # test update behavior of controller; this test can be changed to include multiple chained updates
+    def test_rg_cmd_update(self, rg_cmd_update_input, rg_cmd_update):
+        (reference, _) = rg_cmd_update
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assertions after initial creation
+        desired_node_groups = int(rg_cmd_update_input['NUM_NODE_GROUPS'])
+        desired_replica_count = int(rg_cmd_update_input['REPLICAS_PER_NODE_GROUP'])
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes
+        cc = retrieve_cache_cluster(rg_cmd_update_input['RG_ID'])
+        assert cc is not None
+        assert cc['EngineVersion'] == rg_cmd_update_input['ENGINE_VERSION']
+
+        # increase replica count, wait for resource to sync
+        desired_replica_count += 1
+        desired_total_nodes = (desired_node_groups * (1 + desired_replica_count))
+        patch = {"spec": {"replicasPerNodeGroup": desired_replica_count}}
+        _ = k8s.patch_custom_resource(reference, patch)
+        sleep(DEFAULT_WAIT_SECS)  # required as controller has likely not placed the resource in modifying
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assert new state after increasing replica count
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert len(resource['status']['nodeGroups']) == desired_node_groups
+        assert len(resource['status']['memberClusters']) == desired_total_nodes
+
+        # upgrade engine version, wait for resource to sync
+        desired_engine_version = "5.0.6"
+        patch = {"spec": {"engineVersion": desired_engine_version}}
+        _ = k8s.patch_custom_resource(reference, patch)
+        sleep(DEFAULT_WAIT_SECS)
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
+
+        # assert new state after upgrading engine version
+        resource = k8s.get_resource(reference)
+        assert resource['status']['status'] == "available"
+        assert resource['spec']['engineVersion'] == desired_engine_version
+        cc = retrieve_cache_cluster(rg_cmd_update_input['RG_ID'])
+        assert cc is not None
+        assert cc['EngineVersion'] == desired_engine_version
 
     def test_rg_auth_token(self, rg_auth_token):
         (reference, _) = rg_auth_token

--- a/test/e2e/util.py
+++ b/test/e2e/util.py
@@ -20,6 +20,7 @@ from time import sleep
 
 ec = boto3.client("elasticache")
 
+
 def wait_usergroup_active(usergroup_id: str,
                            wait_periods: int = 10,
                            period_length: int = 60) -> bool:
@@ -40,6 +41,7 @@ def wait_usergroup_active(usergroup_id: str,
 
     logging.error(f"Wait for User Group {usergroup_id} to be active timed out")
     return False
+
 
 def wait_snapshot_available(snapshot_name: str,
                             wait_periods: int = 10,
@@ -62,6 +64,7 @@ def wait_snapshot_available(snapshot_name: str,
     logging.error(f"Wait for snapshot {snapshot_name} to be available timed out")
     return False
 
+
 def wait_snapshot_deleted(snapshot_name: str,
                           wait_periods: int = 10,
                           period_length: int = 60) -> bool:
@@ -77,9 +80,23 @@ def wait_snapshot_deleted(snapshot_name: str,
     logging.error(f"Wait for snapshot {snapshot_name} to be deleted timed out")
     return False
 
+
 # provide a basic nodeGroupConfiguration object of desired size
 def provide_node_group_configuration(size: int):
     ngc = []
     for i in range(1, size+1):
         ngc.append({"nodeGroupID": str(i).rjust(4, '0')})
     return ngc
+
+
+# retrieve first cache cluster found from specified replication group
+def retrieve_cache_cluster(rg_id: str):
+    rg_response = ec.describe_replication_groups(ReplicationGroupId=rg_id)
+
+    rg = rg_response['ReplicationGroups'][0]
+    if len(rg['MemberClusters']) == 0:
+        logging.debug(f"No member clusters found for replication group {rg_id}")
+        return None
+
+    cc_response = ec.describe_cache_clusters(CacheClusterId=rg['MemberClusters'][0])
+    return cc_response['CacheClusters'][0]


### PR DESCRIPTION
Description of changes:

- Regenerate code after upstream code-generator changes
- Bump runtime version to 0.2.0
- Fix failing unit tests
- Improve unit test diff reporting for failing cases
- Add e2e test covering failing scenarios relevant to #22 

This PR will unblock #22. I was considering making the changes and adding them onto this PR but thought it might be more convenient to separate the many newly-generated lines from the actual change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
