### PR TITLE
Update spec fields in ReadOne post_set_output hook

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -55,6 +55,9 @@ resources:
           path: Events
       AuthToken:
         is_secret: true
+    hooks:
+      sdk_read_many_post_set_output:
+        code: "rm.updateSpecFields(ctx, resp.ReplicationGroups[0], &resource{ko})"
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:

--- a/pkg/resource/replication_group/custom_update_api.go
+++ b/pkg/resource/replication_group/custom_update_api.go
@@ -134,7 +134,7 @@ func (rm *resourceManager) modifyReplicationGroup(
 
 	// SecurityGroupIds, EngineVersion
 	if rm.securityGroupIdsDiffer(desired, latest, latestCacheCluster) ||
-		rm.engineVersionsDiffer(desired, latestCacheCluster) {
+		rm.engineVersionsDiffer(desired, latest) {
 		input := rm.newModifyReplicationGroupRequestPayload(desired, latest, latestCacheCluster)
 		resp, respErr := rm.sdkapi.ModifyReplicationGroupWithContext(ctx, input)
 		rm.metrics.RecordAPICall("UPDATE", "ModifyReplicationGroup", respErr)
@@ -168,49 +168,14 @@ func (rm *resourceManager) replicaCountDifference(
 	//   of NodeGroupConfiguration structs that each have a ReplicaCount non-nil-value integer pointer field
 	//   that contains the number of replicas for that particular node group.
 	if desiredSpec.ReplicasPerNodeGroup != nil {
-		return rm.diffReplicasPerNodeGroup(desired, latest)
+		return int(*desiredSpec.ReplicasPerNodeGroup - *latest.ko.Spec.ReplicasPerNodeGroup)
 	} else if desiredSpec.NodeGroupConfiguration != nil {
 		return rm.diffReplicasNodeGroupConfiguration(desired, latest)
 	}
 	return 0
 }
 
-// diffReplicasPerNodeGroup takes desired Spec.ReplicasPerNodeGroup field into account to return
-// positive number if desired replica count is greater than latest replica count
-// negative number if desired replica count is less than latest replica count
-// 0 otherwise
-func (rm *resourceManager) diffReplicasPerNodeGroup(
-	desired *resource,
-	latest *resource,
-) int {
-	desiredSpec := desired.ko.Spec
-	latestStatus := latest.ko.Status
-
-	for _, latestShard := range latestStatus.NodeGroups {
-		latestReplicaCount := 0
-		if latestShard.NodeGroupMembers != nil {
-			if len(latestShard.NodeGroupMembers) > 0 {
-				latestReplicaCount = len(latestShard.NodeGroupMembers) - 1
-			}
-		}
-		if desiredReplicaCount := int(*desiredSpec.ReplicasPerNodeGroup); desiredReplicaCount != latestReplicaCount {
-			nodeGroupID := ""
-			if latestShard.NodeGroupID != nil {
-				nodeGroupID = *latestShard.NodeGroupID
-			}
-			rm.log.V(1).Info(
-				"ReplicasPerNodeGroup differs",
-				"NodeGroup", nodeGroupID,
-				"desired", int(*desiredSpec.ReplicasPerNodeGroup),
-				"latest", latestReplicaCount,
-			)
-			return desiredReplicaCount - latestReplicaCount
-		}
-	}
-	return 0
-}
-
-// diffReplicasPerNodeGroup takes desired Spec.NodeGroupConfiguration slice field into account to return
+// diffReplicasNodeGroupConfiguration takes desired Spec.NodeGroupConfiguration slice field into account to return
 // positive number if desired replica count is greater than latest replica count
 // negative number if desired replica count is less than latest replica count
 // 0 otherwise
@@ -593,11 +558,12 @@ func (rm *resourceManager) getAnyCacheClusterIDFromNodeGroups(
 // it invokes DescribeCacheClusters API to do so
 func (rm *resourceManager) describeCacheCluster(
 	ctx context.Context,
-	latest *resource,
+	resource *resource,
 ) (*svcsdk.CacheCluster, error) {
 	input := &svcsdk.DescribeCacheClustersInput{}
 
-	latestStatus := latest.ko.Status
+	ko := resource.ko
+	latestStatus := ko.Status
 	if latestStatus.NodeGroups == nil {
 		return nil, nil
 	}
@@ -701,7 +667,7 @@ func (rm *resourceManager) newModifyReplicationGroupRequestPayload(
 		input.SetSecurityGroupIds(ids)
 	}
 
-	if rm.engineVersionsDiffer(desired, latestCacheCluster) &&
+	if rm.engineVersionsDiffer(desired, latest) &&
 		desired.ko.Spec.EngineVersion != nil {
 		input.SetEngineVersion(*desired.ko.Spec.EngineVersion)
 	}
@@ -711,27 +677,25 @@ func (rm *resourceManager) newModifyReplicationGroupRequestPayload(
 
 /*
 engineVersionsDiffer returns true if the desired engine version is different
-from the latest observed engine version. Inputs:
-
-desired: the resource representing the desired state
-latestCacheCluster: a CacheCluster object representing one cache node in the replication group, which
-	reveals the currently used engine version for the entire replication group
+from the latest observed engine version, and false if they differ or if
+the desired EngineVersion is nil
 */
 func (rm *resourceManager) engineVersionsDiffer(
 	desired *resource,
-	latestCacheCluster *svcsdk.CacheCluster,
+	latest *resource,
 ) bool {
 	if desired.ko.Spec.EngineVersion == nil {
 		return false
 	}
-	desiredEV := *desired.ko.Spec.EngineVersion
 
-	var latestEV string = ""
-	if latestCacheCluster != nil && latestCacheCluster.EngineVersion != nil {
-		latestEV = *latestCacheCluster.EngineVersion
+	latestEV := ""
+	if latest.ko.Spec.EngineVersion != nil {
+		latestEV = *latest.ko.Spec.EngineVersion
 	}
 
-	return desiredEV != latestEV
+	return *desired.ko.Spec.EngineVersion != latestEV
+
+	//TODO: should Delta be used in this function?
 }
 
 // This method copies the data from given replicationGroup by populating it into copy of supplied resource

--- a/pkg/resource/replication_group/custom_update_api_test.go
+++ b/pkg/resource/replication_group/custom_update_api_test.go
@@ -399,46 +399,30 @@ func TestReplicaCountDifference(t *testing.T) {
 	// setup
 	rm := provideResourceManager()
 	// Tests
-	t.Run("NoDiff=NoSpec_NoStatus", func(t *testing.T) {
-		// no replica configuration in spec as well as status
+	t.Run("NoDiff=DesiredNil_LatestNil", func(t *testing.T) {
+		// neither desired nor latest have either ReplicasPerNodeGroup nor NodeGroupConfiguration set
 		desired := provideResource()
 		latest := provideResource()
 		diff := rm.replicaCountDifference(desired, latest)
 		assert.Nil(desired.ko.Spec.ReplicasPerNodeGroup)
 		assert.Nil(desired.ko.Spec.NodeGroupConfiguration)
-		assert.Nil(latest.ko.Status.NodeGroups)
+		assert.Nil(latest.ko.Spec.ReplicasPerNodeGroup)
+		assert.Nil(latest.ko.Spec.NodeGroupConfiguration)
 		assert.Equal(0, diff)
 	})
-	t.Run("NoDiff=NoSpec_Status.NodeGroups", func(t *testing.T) {
-		// no replica configuration in spec but status has nodes as replicas
+	t.Run("NoDiff=DesiredNonNil_LatestNonNil", func(t *testing.T) {
+		// both desired and latest have ReplicasPerNodeGroup set (but not NodeGroupConfiguration)
 		desired := provideResource()
 		latest := provideResource()
-		replicasCount := 2
-		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(replicasCount, "1001")
-		diff := rm.replicaCountDifference(desired, latest)
-		assert.Nil(desired.ko.Spec.ReplicasPerNodeGroup)
-		assert.Nil(desired.ko.Spec.NodeGroupConfiguration)
-		assert.NotNil(latest.ko.Status.NodeGroups)
-		for _, nodeGroup := range latest.ko.Status.NodeGroups {
-			require.NotNil(nodeGroup.NodeGroupMembers)
-			assert.Equal(replicasCount+1, len(nodeGroup.NodeGroupMembers)) // replica + primary node
-		}
-		assert.Equal(0, diff)
-	})
-	t.Run("NoDiff=Spec.ReplicasPerNodeGroup_Status.NodeGroups", func(t *testing.T) {
-		// replica configuration in spec as 'ReplicasPerNodeGroup' and status has matching number of replicas
-		desired := provideResource()
-		latest := provideResource()
-		replicaCount := int64(2)
-		desired.ko.Spec.ReplicasPerNodeGroup = &replicaCount
-		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(int(replicaCount), "1001")
+		desiredReplicaCount := int64(2)
+		latestReplicaCount := int64(2)
+		desired.ko.Spec.ReplicasPerNodeGroup = &desiredReplicaCount
+		latest.ko.Spec.ReplicasPerNodeGroup = &latestReplicaCount
 		diff := rm.replicaCountDifference(desired, latest)
 		assert.Nil(desired.ko.Spec.NodeGroupConfiguration)
-		assert.NotNil(latest.ko.Status.NodeGroups)
-		for _, nodeGroup := range latest.ko.Status.NodeGroups {
-			require.NotNil(nodeGroup.NodeGroupMembers)
-			assert.Equal(int(replicaCount)+1, len(nodeGroup.NodeGroupMembers)) // replica + primary node
-		}
+		assert.Nil(latest.ko.Spec.NodeGroupConfiguration)
+		assert.NotNil(desired.ko.Spec.ReplicasPerNodeGroup)
+		assert.NotNil(latest.ko.Spec.ReplicasPerNodeGroup)
 		assert.Equal(0, diff)
 	})
 	t.Run("NoDiff=Spec.NodeGroupConfiguration_Status.NodeGroups", func(t *testing.T) {
@@ -469,38 +453,36 @@ func TestReplicaCountDifference(t *testing.T) {
 		// latest status has matching number of replicas with desired 'ReplicasPerNodeGroup'
 		desired := provideResource()
 		latest := provideResource()
-		replicaCount := int64(2)
-		desired.ko.Spec.ReplicasPerNodeGroup = &replicaCount
-		desired.ko.Spec.NodeGroupConfiguration = provideNodeGroupConfigurationWithReplicas(int(replicaCount)+1, "1001", "1002")
-		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(int(replicaCount), "1001")
+		desiredReplicaCount := int64(2)
+		latestReplicaCount := int64(2)
+		desired.ko.Spec.ReplicasPerNodeGroup = &desiredReplicaCount
+		latest.ko.Spec.ReplicasPerNodeGroup = &latestReplicaCount
+		desired.ko.Spec.NodeGroupConfiguration = provideNodeGroupConfigurationWithReplicas(int(desiredReplicaCount)+1, "1001", "1002")
+		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(int(latestReplicaCount), "1001")
+
 		diff := rm.replicaCountDifference(desired, latest)
 		assert.NotNil(desired.ko.Spec.NodeGroupConfiguration)
 		for _, nodeGroupConfig := range desired.ko.Spec.NodeGroupConfiguration {
 			require.NotNil(nodeGroupConfig.ReplicaCount)
-			assert.Equal(int(replicaCount)+1, int(*nodeGroupConfig.ReplicaCount))
+			assert.Equal(int(desiredReplicaCount)+1, int(*nodeGroupConfig.ReplicaCount))
 		}
 		assert.NotNil(latest.ko.Status.NodeGroups)
 		for _, nodeGroup := range latest.ko.Status.NodeGroups {
 			require.NotNil(nodeGroup.NodeGroupMembers)
-			assert.Equal(int(replicaCount)+1, len(nodeGroup.NodeGroupMembers)) // replica + primary node
+			assert.Equal(int(desiredReplicaCount)+1, len(nodeGroup.NodeGroupMembers)) // replica + primary node
 		}
 		assert.Equal(0, diff)
 	})
-	t.Run("DiffIncreaseReplica=Spec.ReplicasPerNodeGroup_Status.NodeGroups", func(t *testing.T) {
-		// replica configuration in spec as 'ReplicasPerNodeGroup' and status has matching number of replicas
+	t.Run("DiffIncreaseReplica=Spec.ReplicasPerNodeGroup", func(t *testing.T) {
+		// desired ReplicasPerNodeGroup is greater than latest.ReplicasPerNodeGroup, NodeGroupConfiguration nil
 		desired := provideResource()
 		latest := provideResource()
 		desiredReplicaCount := int64(2)
-		latestReplicaCount := 1
+		latestReplicaCount := int64(1)
 		desired.ko.Spec.ReplicasPerNodeGroup = &desiredReplicaCount
-		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(latestReplicaCount, "1001")
+		latest.ko.Spec.ReplicasPerNodeGroup = &latestReplicaCount
 		diff := rm.replicaCountDifference(desired, latest)
 		assert.Nil(desired.ko.Spec.NodeGroupConfiguration)
-		assert.NotNil(latest.ko.Status.NodeGroups)
-		for _, nodeGroup := range latest.ko.Status.NodeGroups {
-			require.NotNil(nodeGroup.NodeGroupMembers)
-			assert.Equal(latestReplicaCount+1, len(nodeGroup.NodeGroupMembers)) // replicas + 1 primary node
-		}
 		assert.True(diff > 0) // desired replicas > latest replicas
 	})
 	t.Run("DiffIncreaseReplica=Spec.NodeGroupConfiguration_Status.NodeGroups", func(t *testing.T) {
@@ -526,21 +508,16 @@ func TestReplicaCountDifference(t *testing.T) {
 		}
 		assert.True(diff > 0) // desired replicas > latest replicas
 	})
-	t.Run("DiffDecreaseReplica=Spec.ReplicasPerNodeGroup_Status.NodeGroups", func(t *testing.T) {
-		// replica configuration in spec as 'ReplicasPerNodeGroup' and status has matching number of replicas
+	t.Run("DiffDecreaseReplica=Spec.ReplicasPerNodeGroup", func(t *testing.T) {
+		// desired ReplicasPerNodeGroup is lesser than latest.ReplicasPerNodeGroup, NodeGroupConfiguration nil
 		desired := provideResource()
 		latest := provideResource()
 		desiredReplicaCount := int64(2)
-		latestReplicaCount := 3
+		latestReplicaCount := int64(3)
 		desired.ko.Spec.ReplicasPerNodeGroup = &desiredReplicaCount
-		latest.ko.Status.NodeGroups = provideNodeGroupsWithReplicas(latestReplicaCount, "1001")
+		latest.ko.Spec.ReplicasPerNodeGroup = &latestReplicaCount
 		diff := rm.replicaCountDifference(desired, latest)
 		assert.Nil(desired.ko.Spec.NodeGroupConfiguration)
-		assert.NotNil(latest.ko.Status.NodeGroups)
-		for _, nodeGroup := range latest.ko.Status.NodeGroups {
-			require.NotNil(nodeGroup.NodeGroupMembers)
-			assert.Equal(latestReplicaCount+1, len(nodeGroup.NodeGroupMembers)) // replicas + 1 primary node
-		}
 		assert.True(diff < 0) // desired replicas < latest replicas
 	})
 	t.Run("DiffDecreaseReplica=Spec.NodeGroupConfiguration_Status.NodeGroups", func(t *testing.T) {
@@ -976,45 +953,46 @@ func TestEngineVersionsDiffer(t *testing.T) {
 	// Tests
 	t.Run("NoDiff=NoSpec_NoStatus", func(t *testing.T) {
 		desiredRG := provideResource()
-		latestCacheCluster := provideCacheCluster()
-		require.Nil(desiredRG.ko.Spec.SecurityGroupIDs)
-		require.Nil(latestCacheCluster.SecurityGroups)
-		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
-		assert.False(differ)
-	})
-	t.Run("NoDiff=NoSpec_HasStatus", func(t *testing.T) {
-		desiredRG := provideResource()
-		latestCacheCluster := provideCacheCluster()
-		latestEV := "test-engine-version"
-		latestCacheCluster.EngineVersion = &latestEV
+		latestRG := provideResource()
 		require.Nil(desiredRG.ko.Spec.EngineVersion)
-		require.NotNil(latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
+		require.Nil(latestRG.ko.Spec.EngineVersion)
+		differ := rm.engineVersionsDiffer(desiredRG, latestRG)
 		assert.False(differ)
 	})
-	t.Run("NoDiff=Spec_Status_Match", func(t *testing.T) {
+	t.Run("NoDiff=OnlyDesiredNil", func(t *testing.T) {
 		desiredRG := provideResource()
+		latestRG := provideResource()
+		latestEV := "test-engine-version"
+		latestRG.ko.Spec.EngineVersion = &latestEV
+		require.Nil(desiredRG.ko.Spec.EngineVersion)
+		require.NotNil(latestRG.ko.Spec.EngineVersion)
+		differ := rm.engineVersionsDiffer(desiredRG, latestRG)
+		assert.False(differ)
+	})
+	t.Run("NoDiff=Desired_Latest_Match", func(t *testing.T) {
+		desiredRG := provideResource()
+		latestRG := provideResource()
 		latestEV := "test-engine-version"
 		desiredRG.ko.Spec.EngineVersion = &latestEV
-		latestCacheCluster := provideCacheCluster()
-		latestCacheCluster.EngineVersion = &latestEV
+		latestRG.ko.Spec.EngineVersion = &latestEV
 		require.NotNil(desiredRG.ko.Spec.EngineVersion)
-		require.NotNil(latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
+		require.NotNil(latestRG.ko.Spec.EngineVersion)
+		differ := rm.engineVersionsDiffer(desiredRG, latestRG)
 		assert.False(differ)
 	})
-	t.Run("Diff=Spec_Status_MisMatch", func(t *testing.T) {
+	t.Run("Diff=Desired_Latest_Mismatch", func(t *testing.T) {
 		desiredRG := provideResource()
+		latestRG := provideResource()
 		desiredEV := "desired-test-engine-version"
-		desiredRG.ko.Spec.EngineVersion = &desiredEV
-		latestCacheCluster := provideCacheCluster()
 		latestEV := "latest-test-engine-version"
-		latestCacheCluster.EngineVersion = &latestEV
+
+		desiredRG.ko.Spec.EngineVersion = &desiredEV
+		latestRG.ko.Spec.EngineVersion = &latestEV
 
 		require.NotNil(desiredRG.ko.Spec.EngineVersion)
-		require.NotNil(latestCacheCluster.EngineVersion)
-		require.NotEqual(*desiredRG.ko.Spec.EngineVersion, *latestCacheCluster.EngineVersion)
-		differ := rm.engineVersionsDiffer(desiredRG, latestCacheCluster)
+		require.NotNil(latestRG.ko.Spec.EngineVersion)
+		require.NotEqual(*desiredRG.ko.Spec.EngineVersion, *latestRG.ko.Spec.EngineVersion)
+		differ := rm.engineVersionsDiffer(desiredRG, latestRG)
 		assert.True(differ)
 	})
 }

--- a/pkg/resource/replication_group/manager_test.go
+++ b/pkg/resource/replication_group/manager_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 // TestReadOne_Exists runs resource manager ReadOne test scenario
-// TODO: Declarative Tests make this method redundant;remove this test when Declarative Test runner is checked in.
+// Declarative tests make this test redundant, but it remains to demonstrate the difference between a declarative
+// test (as specified in test_suite.yaml) and a regular imperative test.
 func TestReadOne_Exists(t *testing.T) {
 	assert := assert.New(t)
 
@@ -51,6 +52,10 @@ func TestReadOne_Exists(t *testing.T) {
 	var mockDescribeEventsOutput svcsdk.DescribeEventsOutput
 	testutil.LoadFromFixture(filepath.Join("testdata", "events", "read_many", "rg_cmd_events.json"), &mockDescribeEventsOutput)
 	mocksdkapi.On("DescribeEventsWithContext", mock.Anything, mock.Anything).Return(&mockDescribeEventsOutput, nil)
+	// DescribeCacheClusters
+	var mockDescribeCacheClusterOutput svcsdk.DescribeCacheClustersOutput
+	testutil.LoadFromFixture(filepath.Join("testdata", "cache_clusters", "read_many", "rg_cmd_primary_cache_node.json"), &mockDescribeCacheClusterOutput)
+	mocksdkapi.On("DescribeCacheClustersWithContext", mock.Anything, mock.Anything).Return(&mockDescribeCacheClusterOutput, nil)
 
 	var delegate = testRunnerDelegate{t: t}
 

--- a/pkg/resource/replication_group/post_set_output.go
+++ b/pkg/resource/replication_group/post_set_output.go
@@ -1,0 +1,72 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replication_group
+
+import (
+	"context"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+/*
+	To be called in sdkFind, this function updates the replication group's Spec fields with the latest observed state
+	This requires extra processing of the API response as well as additional API calls, and is necessary because
+	sdkFind does not update many of these Spec fields by default. "resource" is a wrapper around "ko", the object
+	which will eventually be returned as "latest".
+*/
+func (rm *resourceManager) updateSpecFields(
+	ctx context.Context,
+	respRG *svcsdk.ReplicationGroup,
+	resource *resource,
+) {
+
+	// populate relevant ko.Spec fields with observed state of respRG.NodeGroups
+	setReplicasPerNodeGroup(respRG, resource)
+
+	//TODO: set Spec NodeGroupConfiguration
+
+	// updating some Spec fields requires a DescribeCacheClusters call
+	latestCacheCluster, err := rm.describeCacheCluster(ctx, resource)
+	if err == nil && latestCacheCluster != nil {
+		setEngineVersion(latestCacheCluster, resource)
+	}
+}
+
+// if ReplicasPerNodeGroup was given in desired.Spec, update ko.Spec with the latest observed value
+func setReplicasPerNodeGroup(
+	respRG *svcsdk.ReplicationGroup,
+	resource *resource,
+) {
+	ko := resource.ko
+	if respRG.NodeGroups != nil && ko.Spec.ReplicasPerNodeGroup != nil {
+		// if ReplicasPerNodeGroup is specified, all node groups should have the same # replicas so use the first
+		nodeGroup := respRG.NodeGroups[0]
+		if nodeGroup != nil && nodeGroup.NodeGroupMembers != nil {
+			if len(nodeGroup.NodeGroupMembers) > 0 {
+				*ko.Spec.ReplicasPerNodeGroup = int64(len(nodeGroup.NodeGroupMembers) - 1)
+			}
+		}
+	}
+}
+
+// if EngineVersion was specified in desired.Spec, update ko.Sepc with the latest observed value (if non-nil)
+func setEngineVersion(
+	latestCacheCluster *svcsdk.CacheCluster,
+	resource *resource,
+) {
+	ko := resource.ko
+	if ko.Spec.EngineVersion != nil && latestCacheCluster.EngineVersion != nil {
+		*ko.Spec.EngineVersion = *latestCacheCluster.EngineVersion
+	}
+}

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -340,6 +340,7 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
+	rm.updateSpecFields(ctx, resp.ReplicationGroups[0], &resource{ko})
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
@@ -4,29 +4,67 @@ kind: ReplicationGroup
 spec:
   cacheNodeType: cache.t3.micro
   engine: redis
+  engineVersion: 5.0.0 # this should still be the old engine version
   numNodeGroups: 1
-  replicasPerNodeGroup: 2 # new replica hasn't been added, but 2 comes from desired and isn't overwritten in custom modify code
+  replicasPerNodeGroup: 1
   replicationGroupDescription: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
     ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
   authTokenEnabled: false
   automaticFailover: disabled
   clusterEnabled: false
   conditions:
-    - status: "False"
+    - status: "True"
       type: ACK.ResourceSynced
   description: cluster-mode disabled RG
   events:
-    - date: "2021-03-30T20:12:00Z"
+    - date: "2021-04-13T19:07:05Z"
       message: Replication group rg-cmd created
   globalReplicationGroupInfo: {}
   memberClusters:
     - rg-cmd-001
     - rg-cmd-002
-    - rg-cmd-003
   multiAZ: disabled
   nodeGroups:
     - nodeGroupID: "0001"
@@ -51,6 +89,6 @@ status:
       readerEndpoint:
         address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
         port: 6379
-      status: modifying
+      status: available
   pendingModifiedValues: {}
-  status: modifying
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
@@ -5,18 +5,62 @@ spec:
   cacheNodeType: cache.t3.micro
   engine: redis
   numNodeGroups: 1
-  replicasPerNodeGroup: 2 # new replica hasn't been added, but 2 comes from desired and isn't overwritten in custom modify code
+  replicasPerNodeGroup: 1 # as this is the latest state, replicasPerNodeGroup should be consistent with memberClusters/nodeGroups
   replicationGroupDescription: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:
     arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
     ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+    - cache.m3.large
+    - cache.m3.medium
+    - cache.m3.xlarge
+    - cache.m4.10xlarge
+    - cache.m4.2xlarge
+    - cache.m4.4xlarge
+    - cache.m4.large
+    - cache.m4.xlarge
+    - cache.m5.12xlarge
+    - cache.m5.24xlarge
+    - cache.m5.2xlarge
+    - cache.m5.4xlarge
+    - cache.m5.large
+    - cache.m5.xlarge
+    - cache.m6g.large
+    - cache.r3.2xlarge
+    - cache.r3.4xlarge
+    - cache.r3.8xlarge
+    - cache.r3.large
+    - cache.r3.xlarge
+    - cache.r4.16xlarge
+    - cache.r4.2xlarge
+    - cache.r4.4xlarge
+    - cache.r4.8xlarge
+    - cache.r4.large
+    - cache.r4.xlarge
+    - cache.r5.12xlarge
+    - cache.r5.24xlarge
+    - cache.r5.2xlarge
+    - cache.r5.4xlarge
+    - cache.r5.large
+    - cache.r5.xlarge
+    - cache.r6g.2xlarge
+    - cache.r6g.4xlarge
+    - cache.r6g.8xlarge
+    - cache.r6g.large
+    - cache.r6g.xlarge
+    - cache.t2.medium
+    - cache.t2.micro
+    - cache.t2.small
+    - cache.t3.medium
+    - cache.t3.small
   authTokenEnabled: false
   automaticFailover: disabled
   clusterEnabled: false
   conditions:
-    - status: "False"
+    - status: "True"
       type: ACK.ResourceSynced
   description: cluster-mode disabled RG
   events:
@@ -26,7 +70,6 @@ status:
   memberClusters:
     - rg-cmd-001
     - rg-cmd-002
-    - rg-cmd-003
   multiAZ: disabled
   nodeGroups:
     - nodeGroupID: "0001"
@@ -51,6 +94,6 @@ status:
       readerEndpoint:
         address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
         port: 6379
-      status: modifying
+      status: available
   pendingModifiedValues: {}
-  status: modifying
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
@@ -4,7 +4,7 @@ kind: ReplicationGroup
 spec:
   cacheNodeType: cache.t3.micro
   engine: redis
-  engineVersion: 5.0.6
+  engineVersion: 5.0.6 # resource has 5.0.0 but custom modify code copies desired EV to latest and doesn't overwrite it
   numNodeGroups: 1
   replicasPerNodeGroup: 1
   replicationGroupDescription: cluster-mode disabled RG

--- a/pkg/resource/replication_group/testdata/test_suite.yaml
+++ b/pkg/resource/replication_group/testdata/test_suite.yaml
@@ -49,6 +49,8 @@ tests:
               output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types.json"
             - operation: DescribeEventsWithContext
               output_fixture: "events/read_many/rg_cmd_events.json"
+            - operation: DescribeCacheClustersWithContext
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: ReadOne
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml"
@@ -64,15 +66,17 @@ tests:
               output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types.json"
             - operation: DescribeEventsWithContext
               output_fixture: "events/read_many/rg_cmd_events.json"
+            - operation: DescribeCacheClustersWithContext
+              output_fixture: "cache_clusters/read_many/rg_cmd_primary_cache_node.json"
         invoke: ReadOne
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml" #unchanged
           error: nil
       - name: "Update=IncreaseReplicaCount"
         description: "Ensure a replica is added once a new config is provided"
-        given: # currently, desired and latest end up being the same in the reconciler (despite a newly applied config)
+        given:
           desired_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
-          latest_state: "replication_group/cr/rg_cmd_before_increase_replica.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_increase_replica_latest.yaml"
           svc_api:
             - operation: IncreaseReplicaCountWithContext
               output_fixture: "replication_group/update/rg_cmd_increase_replica_initiated.json"
@@ -94,9 +98,9 @@ tests:
           error: nil
       - name: "Update=UpgradeEngine"
         description: "Upgrade Redis engine version from 5.0.0 to a newer version"
-        given: # desired and latest same due to ReadOne behavior, same as increase replica count case
+        given:
           desired_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
-          latest_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml"
+          latest_state: "replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml"
           svc_api:
             - operation: ModifyReplicationGroupWithContext
               output_fixture: "replication_group/update/rg_cmd_engine_upgrade_initiated.json"


### PR DESCRIPTION
Description of changes:
Related to https://github.com/aws-controllers-k8s/elasticache-controller/pull/22

To recap, in order to trigger the `Update` code, there needs to be a Spec difference between `desired` and `latest`. The generated `ReadOne` code often doesn't update `latest.Spec` with the latest observed state, since determining the latest observed state often requires some processing or additional API calls. There are many fields this applies to, but this PR starts with `ReplicasPerNodeGroup` and `EngineVersion`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
