### PR TITLE
fix Prow e2e test run failures

### DIFF
--- a/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
@@ -10,6 +10,6 @@ spec:
   snapshotName: $SNAPSHOT_NAME
   numCacheClusters: 3
   preferredCacheClusterAZs:
-    - us-east-1a
-    - us-east-1b
-    - us-east-1c
+    - us-west-2a
+    - us-west-2b
+    - us-west-2c

--- a/test/e2e/resources/replicationgroup_input_coverage.yaml
+++ b/test/e2e/resources/replicationgroup_input_coverage.yaml
@@ -4,7 +4,6 @@ metadata:
   name: $RG_ID
 spec:
   atRestEncryptionEnabled: true
-  authToken: testplaintexttoken
   autoMinorVersionUpgrade: true
   automaticFailoverEnabled: true
   cacheNodeType: cache.t3.small
@@ -16,17 +15,17 @@ spec:
   multiAZEnabled: true
   nodeGroupConfiguration:
     - nodeGroupID: "1111"
-      primaryAvailabilityZone: us-east-1a
+      primaryAvailabilityZone: us-west-2a
       replicaAvailabilityZones:
-        - us-east-1b
+        - us-west-2b
       replicaCount: 1
       slots: 0-5999
     - nodeGroupID: "2222"
-      primaryAvailabilityZone: us-east-1c
+      primaryAvailabilityZone: us-west-2c
       replicaAvailabilityZones:
-        - us-east-1d
-        - us-east-1a
-        - us-east-1b
+        - us-west-2a
+        - us-west-2c
+        - us-west-2b
       replicaCount: 3
       slots: 6000-16383
   notificationTopicARN: $SNS_TOPIC_ARN
@@ -43,7 +42,7 @@ spec:
     - key: service
       value: elasticache
     - key: region
-      value: us-east-1
+      value: us-west-2
   transitEncryptionEnabled: true
   userGroupIDs:
     - $USERGROUP_ID

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -211,6 +211,8 @@ class TestReplicationGroup:
         assert cc is not None
         assert cc['EngineVersion'] == desired_engine_version
 
+    # TODO: remove annotation once https://github.com/aws-controllers-k8s/community/issues/745 is resolved
+    @pytest.mark.blocked
     def test_rg_auth_token(self, rg_auth_token):
         (reference, _) = rg_auth_token
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)


### PR DESCRIPTION
Description of changes:

Address e2e test failures:
- `test_rg_input_coverage` was failing because the type of the `authToken` field has changed since the test was written
- `test_rg_auth_token` was failing because the controller does not have permissions to list secrets. For now, we are skipping this test. See issue https://github.com/aws-controllers-k8s/community/issues/745
- `test_rg_cmd_fromsnapshot` succeeds locally but failed in the last Prow run. This was likely due to a region mismatch (tests run in us-west-2, input yamls specify us-east-1 AZs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
