### PR TITLE
Delete replication group to wait for delete completion

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -58,6 +58,10 @@ resources:
     hooks:
       sdk_read_many_post_set_output:
         code: "rm.updateSpecFields(ctx, resp.ReplicationGroups[0], &resource{ko})"
+      sdk_delete_pre_build_request:
+        template_path: hooks/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/sdk_delete_post_request.go.tpl
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:

--- a/pkg/resource/replication_group/hooks.go
+++ b/pkg/resource/replication_group/hooks.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replication_group
+
+import (
+	"errors"
+
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+)
+
+var (
+	requeueWaitWhileDeleting = ackrequeue.NeededAfter(
+		errors.New("Delete is in progress."),
+		ackrequeue.DefaultRequeueAfterDuration,
+	)
+)
+
+// isDeleting returns true if supplied replication group resource state is 'deleting'
+func isDeleting(r *resource) bool {
+	if r == nil || r.ko.Status.Status == nil {
+		return false
+	}
+	status := *r.ko.Status.Status
+	return status == "deleting"
+}

--- a/pkg/resource/replication_group/post_set_output.go
+++ b/pkg/resource/replication_group/post_set_output.go
@@ -30,7 +30,9 @@ func (rm *resourceManager) updateSpecFields(
 	respRG *svcsdk.ReplicationGroup,
 	resource *resource,
 ) {
-
+	if isDeleting(resource) {
+		return
+	}
 	// populate relevant ko.Spec fields with observed state of respRG.NodeGroups
 	setReplicasPerNodeGroup(respRG, resource)
 

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_delete_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_delete_initiated.yaml
@@ -1,0 +1,103 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+# omitted metadata
+spec:
+  atRestEncryptionEnabled: false
+  cacheNodeType: cache.t3.micro
+  engine: redis
+  numNodeGroups: 1
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: cluster-mode disabled RG
+  replicationGroupID: rg-cmd
+  snapshotRetentionLimit: 0
+  snapshotWindow: "10:00-11:00"
+  transitEncryptionEnabled: false
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+  - cache.m3.2xlarge
+  - cache.m3.large
+  - cache.m3.medium
+  - cache.m3.xlarge
+  - cache.m4.10xlarge
+  - cache.m4.2xlarge
+  - cache.m4.4xlarge
+  - cache.m4.large
+  - cache.m4.xlarge
+  - cache.m5.12xlarge
+  - cache.m5.24xlarge
+  - cache.m5.2xlarge
+  - cache.m5.4xlarge
+  - cache.m5.large
+  - cache.m5.xlarge
+  - cache.m6g.large
+  - cache.r3.2xlarge
+  - cache.r3.4xlarge
+  - cache.r3.8xlarge
+  - cache.r3.large
+  - cache.r3.xlarge
+  - cache.r4.16xlarge
+  - cache.r4.2xlarge
+  - cache.r4.4xlarge
+  - cache.r4.8xlarge
+  - cache.r4.large
+  - cache.r4.xlarge
+  - cache.r5.12xlarge
+  - cache.r5.24xlarge
+  - cache.r5.2xlarge
+  - cache.r5.4xlarge
+  - cache.r5.large
+  - cache.r5.xlarge
+  - cache.r6g.2xlarge
+  - cache.r6g.4xlarge
+  - cache.r6g.8xlarge
+  - cache.r6g.large
+  - cache.r6g.xlarge
+  - cache.t2.medium
+  - cache.t2.micro
+  - cache.t2.small
+  - cache.t3.medium
+  - cache.t3.small
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  description: cluster-mode disabled RG
+  events:
+  - date: "2021-03-30T20:12:00Z"
+    message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+  - rg-cmd-001
+  - rg-cmd-002
+  multiAZ: disabled
+  nodeGroups:
+  - nodeGroupID: "0001"
+    nodeGroupMembers:
+    - cacheClusterID: rg-cmd-001
+      cacheNodeID: "0001"
+      currentRole: primary
+      preferredAvailabilityZone: us-east-1b
+      readEndpoint:
+        address: rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com
+        port: 6379
+    - cacheClusterID: rg-cmd-002
+      cacheNodeID: "0001"
+      currentRole: replica
+      preferredAvailabilityZone: us-east-1d
+      readEndpoint:
+        address: rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com
+        port: 6379
+    primaryEndpoint:
+      address: rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com
+      port: 6379
+    readerEndpoint:
+      address: rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com
+      port: 6379
+    status: available
+  pendingModifiedValues: {}
+  status: deleting

--- a/pkg/resource/replication_group/testdata/replication_group/read_one/rg_cmd_delete_initiated.json
+++ b/pkg/resource/replication_group/testdata/replication_group/read_one/rg_cmd_delete_initiated.json
@@ -1,0 +1,61 @@
+{
+    "ReplicationGroups": [
+        {
+            "Status": "deleting",
+            "MultiAZ": "disabled",
+            "Description": "cluster-mode disabled RG",
+            "NodeGroups": [
+                {
+                    "Status": "available",
+                    "NodeGroupMembers": [
+                        {
+                            "CurrentRole": "primary",
+                            "PreferredAvailabilityZone": "us-east-1b",
+                            "CacheNodeId": "0001",
+                            "ReadEndpoint": {
+                                "Port": 6379,
+                                "Address": "rg-cmd-001.xxxxxx.0001.use1.cache.amazonaws.com"
+                            },
+                            "CacheClusterId": "rg-cmd-001"
+                        },
+                        {
+                            "CurrentRole": "replica",
+                            "PreferredAvailabilityZone": "us-east-1d",
+                            "CacheNodeId": "0001",
+                            "ReadEndpoint": {
+                                "Port": 6379,
+                                "Address": "rg-cmd-002.xxxxxx.0001.use1.cache.amazonaws.com"
+                            },
+                            "CacheClusterId": "rg-cmd-002"
+                        }
+                    ],
+                    "ReaderEndpoint": {
+                        "Port": 6379,
+                        "Address": "rg-cmd-ro.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+                    },
+                    "NodeGroupId": "0001",
+                    "PrimaryEndpoint": {
+                        "Port": 6379,
+                        "Address": "rg-cmd.xxxxxx.ng.0001.use1.cache.amazonaws.com"
+                    }
+                }
+            ],
+            "AuthTokenEnabled": false,
+            "AtRestEncryptionEnabled": false,
+            "ClusterEnabled": false,
+            "ReplicationGroupId": "rg-cmd",
+            "GlobalReplicationGroupInfo": {},
+            "SnapshotRetentionLimit": 0,
+            "AutomaticFailover": "disabled",
+            "TransitEncryptionEnabled": false,
+            "SnapshotWindow": "10:00-11:00",
+            "MemberClusters": [
+                "rg-cmd-001",
+                "rg-cmd-002"
+            ],
+            "CacheNodeType": "cache.t3.micro",
+            "ARN": "arn:aws:elasticache:us-east-1:012345678910:replicationgroup:rg-cmd",
+            "PendingModifiedValues": {}
+        }
+    ]
+}

--- a/pkg/resource/replication_group/testdata/test_suite.yaml
+++ b/pkg/resource/replication_group/testdata/test_suite.yaml
@@ -110,17 +110,47 @@ tests:
         expect:
           latest_state: "replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml"
           error: nil
-      - name: "Delete"
-        description: "Delete cluster mode-disabled RG"
+      - name: "DeleteImmediate"
+        description: "Delete cluster mode-disabled RG. Immediately deleted."
         given:
           desired_state: "replication_group/cr/rg_cmd_create_completed.yaml"
           svc_api:
             - operation: DeleteReplicationGroupWithContext
               output_fixture: "replication_group/delete/rg_cmd_delete_initiated.json"
+            - operation: DescribeReplicationGroupsWithContext
+              error:
+                code: ReplicationGroupNotFoundFault
+                message: "ReplicationGroup rg-cmd not found"
         invoke: Delete
         expect: # for the delete case we don't expect a new latest state or a non-nil error
           latest_state: nil
           error: nil
+      - name: "DeleteInitiated"
+        description: "Delete cluster mode-disabled RG. RG moves from available to deleting state."
+        given:
+          desired_state: "replication_group/cr/rg_cmd_create_completed.yaml"
+          svc_api:
+            - operation: DeleteReplicationGroupWithContext
+              output_fixture: "replication_group/delete/rg_cmd_delete_initiated.json"
+            - operation: DescribeReplicationGroupsWithContext
+              output_fixture: "replication_group/read_one/rg_cmd_delete_initiated.json"
+            - operation: ListAllowedNodeTypeModifications
+              output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types.json"
+            - operation: DescribeEventsWithContext
+              output_fixture: "events/read_many/rg_cmd_events.json"
+        invoke: Delete
+        expect: # for the delete case we don't expect a new latest state or a non-nil error
+          latest_state: nil
+          error: "Delete is in progress."
+      - name: "Deleting"
+        description: "Delete cluster mode-disabled RG. Retry scenario, RG is in deleting state."
+        given:
+          desired_state: "replication_group/cr/rg_cmd_delete_initiated.yaml"
+          svc_api:
+        invoke: Delete
+        expect: # for the delete case we don't expect a new latest state or a non-nil error
+          latest_state: nil
+          error: "Delete is in progress."
   - name: Cluster mode enabled replication group
     description: Cluster mode enabled replication group CRUD tests
     scenarios:

--- a/templates/hooks/sdk_delete_post_request.go.tpl
+++ b/templates/hooks/sdk_delete_post_request.go.tpl
@@ -1,0 +1,8 @@
+	if respErr == nil {
+		if foundResource, err := rm.sdkFind(ctx, r); err != ackerr.NotFound {
+			if isDeleting(foundResource) {
+				return requeueWaitWhileDeleting
+			}
+			return err
+		}
+	}

--- a/templates/hooks/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,4 @@
+	if isDeleting(r) {
+		return requeueWaitWhileDeleting
+	}
+


### PR DESCRIPTION
Issue #, if available:

Replication group delete takes some time to delete while `kubectl delete -f replication_group.yaml` removes the custom resource record from cluster.

Description of changes:

This PR adds logic inside `sdk::sdkDelete()` to requeue reconcile while replication group is deleting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
