### PR TITLE
address regression with User code, fix RG deletion test

### DIFF
--- a/pkg/resource/user/delta_util.go
+++ b/pkg/resource/user/delta_util.go
@@ -23,12 +23,10 @@ func filterDelta(
 ) {
 	// the returned AccessString can be different than the specified one; as long as the last requested AccessString
 	// matches the currently desired one, remove this difference from the delta
-	//TODO: revert this call to Spec.AccessString once we have a new implementation of it
-	if delta.DifferentAt("AccessString") {
+	if delta.DifferentAt("Spec.AccessString") {
 		if *desired.ko.Spec.AccessString == *desired.ko.Status.LastRequestedAccessString {
 
-			//TODO: revert the call to Spec.AccessString once removeFromDelta implementation changes
-			removeFromDelta(delta, "AccessString")
+			removeFromDelta(delta, "Spec.AccessString")
 		}
 	}
 }
@@ -43,7 +41,7 @@ func removeFromDelta(
 	differences := delta.Differences
 
 	// identify index of Difference to remove
-	//TODO: change once we get a Path.Equals or similar method
+	//TODO: this could require a stricter Path.Equals down the road
 	var i *int = nil
 	for j, diff := range differences {
 		if diff.Path.Contains(subject) {

--- a/pkg/resource/user/post_build_request.go
+++ b/pkg/resource/user/post_build_request.go
@@ -26,13 +26,11 @@ func (rm *resourceManager) populateUpdatePayload(
 	r *resource,
 	delta *ackcompare.Delta,
 ) {
-	//TODO: change all calls to DifferentAt to include full path once the implementation is clarified
-
-	if delta.DifferentAt("AccessString") && r.ko.Spec.AccessString != nil {
+	if delta.DifferentAt("Spec.AccessString") && r.ko.Spec.AccessString != nil {
 		input.AccessString = r.ko.Spec.AccessString
 	}
 
-	if delta.DifferentAt("NoPasswordRequired") && r.ko.Spec.NoPasswordRequired != nil {
+	if delta.DifferentAt("Spec.NoPasswordRequired") && r.ko.Spec.NoPasswordRequired != nil {
 		input.NoPasswordRequired = r.ko.Spec.NoPasswordRequired
 	}
 


### PR DESCRIPTION
Description of changes:

- Change User code to be compatible with https://github.com/aws-controllers-k8s/runtime/pull/20
- Fix RG deletion test (pytest was complaining about a direct call to a fixture)

Local e2e test run:
```
============================================================================ test session starts =============================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /elasticache-controller/tests/e2e
plugins: xdist-2.2.0, forked-1.3.0
[gw0] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
[gw1] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
[gw2] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
[gw3] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
[gw4] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
[gw5] Python 3.8.10 (default, May  4 2021, 19:07:02)  -- [GCC 10.2.1 20201203]
gw0 [9] / gw1 [9] / gw2 [9] / gw3 [9] / gw4 [9] / gw5 [9]
scheduling tests via LoadScheduling

tests/test_replicationgroup.py::TestReplicationGroup::test_rg_input_coverage 
tests/test_replicationgroup.py::TestReplicationGroup::test_rg_cmd_update 
tests/test_replicationgroup.py::TestReplicationGroup::test_rg_delete 
tests/test_replicationgroup_largecluster.py::TestReplicationGroupLargeCluster::test_rg_largecluster 
tests/test_replicationgroup.py::TestReplicationGroup::test_rg_cmd_fromsnapshot 
tests/test_replicationgroup.py::TestReplicationGroup::test_rg_auth_token 
[gw5] [ 11%] SKIPPED tests/test_replicationgroup_largecluster.py::TestReplicationGroupLargeCluster::test_rg_largecluster 
[gw3] [ 22%] SKIPPED tests/test_replicationgroup.py::TestReplicationGroup::test_rg_auth_token x
[gw1] [ 33%] PASSED tests/test_replicationgroup.py::TestReplicationGroup::test_rg_cmd_fromsnapshot 
[gw0] [ 44%] PASSED tests/test_replicationgroup.py::TestReplicationGroup::test_rg_input_coverage 
[gw4] [ 55%] PASSED tests/test_replicationgroup.py::TestReplicationGroup::test_rg_delete 
tests/test_user.py::TestUser::test_CRUD 
[gw1] [ 66%] PASSED tests/test_user.py::TestUser::test_CRUD 
tests/test_snapshot.py::TestSnapshot::test_snapshot_kms 
[gw2] [ 77%] PASSED tests/test_replicationgroup.py::TestReplicationGroup::test_rg_cmd_update 
[gw0] [ 88%] PASSED tests/test_snapshot.py::TestSnapshot::test_snapshot_kms 
tests/test_usergroup.py::TestUserGroup::test_user_group_create_update 
[gw2] [100%] PASSED tests/test_usergroup.py::TestUserGroup::test_user_group_create_update 

================================================================= 7 passed, 2 skipped in 1688.28s (0:28:08) ==================================================================

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
