### PR TITLE
fix deletion assertions in user e2e tests

### DIFF
--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -23,9 +23,10 @@ from acktest.k8s import resource as k8s
 
 from time import sleep
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_elasticache_resource
+from e2e.util import assert_user_deletion
 
 RESOURCE_PLURAL = "users"
-DEFAULT_WAIT_SECS = 90
+DEFAULT_WAIT_SECS = 30
 
 
 @pytest.fixture(scope="module")
@@ -57,8 +58,7 @@ def user_nopass(user_nopass_input, elasticache_client):
     # teardown: delete in k8s, assert user does not exist in AWS
     k8s.delete_custom_resource(reference)
     sleep(DEFAULT_WAIT_SECS)
-    with pytest.raises(botocore.exceptions.ClientError, match="UserNotFound"):
-        _ = elasticache_client.describe_users(UserId=user_nopass_input["USER_ID"])
+    assert_user_deletion(user_nopass_input['USER_ID'])
 
 
 # create secrets for below user password test
@@ -104,8 +104,7 @@ def user_password(user_password_input, elasticache_client):
     # teardown: delete in k8s, assert user does not exist in AWS
     k8s.delete_custom_resource(reference)
     sleep(DEFAULT_WAIT_SECS)
-    with pytest.raises(botocore.exceptions.ClientError, match="UserNotFound"):
-        _ = elasticache_client.describe_users(UserId=user_password_input["USER_ID"])
+    assert_user_deletion(user_password_input['USER_ID'])
 
 
 @service_marker

--- a/test/e2e/util.py
+++ b/test/e2e/util.py
@@ -81,6 +81,17 @@ def wait_snapshot_deleted(snapshot_name: str,
     return False
 
 
+# assert that either: 1) deletion has been initiated, or 2) deletion has been completed
+#   on the service-side
+def assert_user_deletion(user_id: str):
+    try:
+        resp = ec.describe_users(UserId=user_id)
+        assert len(resp['Users']) == 1
+        assert resp['Users'][0]['Status'] == 'deleting'  # at this point, deletion is a server-side responsibility
+    except ec.exceptions.UserNotFoundFault:
+        pass  # we only expect this particular exception (if deletion has already completed)
+
+
 # provide a basic nodeGroupConfiguration object of desired size
 def provide_node_group_configuration(size: int):
     ngc = []


### PR DESCRIPTION
User tests were failing upon asserting the deletion (the logic I initially wrote was somewhat unsophisticated)

Description of changes:
Ensure either 1) the User is deleting, or 2) the User has already been deleted (as opposed to waiting an arbitrary amount of time before assuming the User should be deleted)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
