### PR TITLE
ElastiCache Fixes with new code generator

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-07-19T17:01:25Z"
-  build_hash: a8283f525037c5b9c42a4c3c723ba70e86678e17
-  go_version: go1.15.2 darwin/amd64
-  version: v0.6.0
-api_directory_checksum: 04701e412e7e4597466c1d56571be2c5de2b1e27
+  build_date: "2021-07-21T18:35:06Z"
+  build_hash: 4d4ca8eb4fbd267693056f226715547387463a35
+  go_version: go1.16.4 darwin/amd64
+  version: v0.7.0
+api_directory_checksum: 7e815ddf23bddf7f7d999a134be3880ceb6dd23a
 api_version: v1alpha1
 aws_sdk_go_version: ""
 generator_config_info:
-  file_checksum: 91149587edd7737e80d84b59045e6fcd8fb1a044
+  file_checksum: 7700b908b185617f036c6d6a04e0d16f9d9cca11
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-07-19 17:01:45.007056 +0000 UTC
+  timestamp: 2021-07-21 21:05:27.169347 +0000 UTC

--- a/apis/v1alpha1/cache_parameter_group.go
+++ b/apis/v1alpha1/cache_parameter_group.go
@@ -48,18 +48,23 @@ type CacheParameterGroupStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// A list of events. Each element in the list contains detailed information
 	// about one event.
+	// +kubebuilder:validation:Optional
 	Events []*Event `json:"events,omitempty"`
 	// Indicates whether the parameter group is associated with a Global datastore
+	// +kubebuilder:validation:Optional
 	IsGlobal *bool `json:"isGlobal,omitempty"`
 	// A list of Parameter instances.
+	// +kubebuilder:validation:Optional
 	Parameters []*Parameter `json:"parameters,omitempty"`
 }
 

--- a/apis/v1alpha1/cache_subnet_group.go
+++ b/apis/v1alpha1/cache_subnet_group.go
@@ -48,19 +48,24 @@ type CacheSubnetGroupStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// A list of events. Each element in the list contains detailed information
 	// about one event.
+	// +kubebuilder:validation:Optional
 	Events []*Event `json:"events,omitempty"`
 	// A list of subnets associated with the cache subnet group.
+	// +kubebuilder:validation:Optional
 	Subnets []*Subnet `json:"subnets,omitempty"`
 	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
 	// group.
+	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcID,omitempty"`
 }
 

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -222,3 +222,5 @@ ignore:
     - CreateReplicationGroupInput.Tags
     - CreateUserInput.Tags
     - CreateUserGroupInput.Tags
+    - CreateReplicationGroupInput.AutoMinorVersionUpgrade
+    - CreateReplicationGroupInput.NumCacheClusters

--- a/apis/v1alpha1/replication_group.go
+++ b/apis/v1alpha1/replication_group.go
@@ -57,8 +57,6 @@ type ReplicationGroupSpec struct {
 	// For more information, see AUTH password (http://redis.io/commands/AUTH) at
 	// http://redis.io/commands/AUTH.
 	AuthToken *ackv1alpha1.SecretKeyReference `json:"authToken,omitempty"`
-	// This parameter is currently disabled.
-	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
 	// Specifies whether a read-only replica is automatically promoted to read/write
 	// primary if the existing primary fails.
 	//
@@ -170,18 +168,6 @@ type ReplicationGroupSpec struct {
 	//
 	// The Amazon SNS topic owner must be the same as the cluster owner.
 	NotificationTopicARN *string `json:"notificationTopicARN,omitempty"`
-	// The number of clusters this replication group initially has.
-	//
-	// This parameter is not used if there is more than one node group (shard).
-	// You should use ReplicasPerNodeGroup instead.
-	//
-	// If AutomaticFailoverEnabled is true, the value of this parameter must be
-	// at least 2. If AutomaticFailoverEnabled is false you can omit this parameter
-	// (it will default to 1), or you can explicitly set it to a value between 2
-	// and 6.
-	//
-	// The maximum permitted value for NumCacheClusters is 6 (1 primary plus 5 replicas).
-	NumCacheClusters *int64 `json:"numCacheClusters,omitempty"`
 	// An optional parameter that specifies the number of node groups (shards) for
 	// this Redis (cluster mode enabled) replication group. For Redis (cluster mode
 	// disabled) either omit this parameter or set it to 1.
@@ -319,16 +305,19 @@ type ReplicationGroupStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// A string list, each element of which specifies a cache node type which you
 	// can use to scale your cluster or replication group. When scaling down a Redis
 	// cluster or replication group using ModifyCacheCluster or ModifyReplicationGroup,
 	// use a value from this list for the CacheNodeType parameter.
+	// +kubebuilder:validation:Optional
 	AllowedScaleDownModifications []*string `json:"allowedScaleDownModifications,omitempty"`
 	// A string list, each element of which specifies a cache node type which you
 	// can use to scale your cluster or replication group.
@@ -336,54 +325,71 @@ type ReplicationGroupStatus struct {
 	// When scaling up a Redis cluster or replication group using ModifyCacheCluster
 	// or ModifyReplicationGroup, use a value from this list for the CacheNodeType
 	// parameter.
+	// +kubebuilder:validation:Optional
 	AllowedScaleUpModifications []*string `json:"allowedScaleUpModifications,omitempty"`
 	// A flag that enables using an AuthToken (password) when issuing Redis commands.
 	//
 	// Default: false
+	// +kubebuilder:validation:Optional
 	AuthTokenEnabled *bool `json:"authTokenEnabled,omitempty"`
 	// The date the auth token was last modified
+	// +kubebuilder:validation:Optional
 	AuthTokenLastModifiedDate *metav1.Time `json:"authTokenLastModifiedDate,omitempty"`
 	// Indicates the status of automatic failover for this Redis replication group.
+	// +kubebuilder:validation:Optional
 	AutomaticFailover *string `json:"automaticFailover,omitempty"`
 	// A flag indicating whether or not this replication group is cluster enabled;
 	// i.e., whether its data can be partitioned across multiple shards (API/CLI:
 	// node groups).
 	//
 	// Valid values: true | false
+	// +kubebuilder:validation:Optional
 	ClusterEnabled *bool `json:"clusterEnabled,omitempty"`
 	// The configuration endpoint for this replication group. Use the configuration
 	// endpoint to connect to this replication group.
+	// +kubebuilder:validation:Optional
 	ConfigurationEndpoint *Endpoint `json:"configurationEndpoint,omitempty"`
 	// The user supplied description of the replication group.
+	// +kubebuilder:validation:Optional
 	Description *string `json:"description,omitempty"`
 	// A list of events. Each element in the list contains detailed information
 	// about one event.
+	// +kubebuilder:validation:Optional
 	Events []*Event `json:"events,omitempty"`
 	// The name of the Global datastore and role of this replication group in the
 	// Global datastore.
+	// +kubebuilder:validation:Optional
 	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo `json:"globalReplicationGroupInfo,omitempty"`
 	// Returns the destination, format and type of the logs.
+	// +kubebuilder:validation:Optional
 	LogDeliveryConfigurations []*LogDeliveryConfiguration `json:"logDeliveryConfigurations,omitempty"`
 	// The names of all the cache clusters that are part of this replication group.
+	// +kubebuilder:validation:Optional
 	MemberClusters []*string `json:"memberClusters,omitempty"`
 	// The outpost ARNs of the replication group's member clusters.
+	// +kubebuilder:validation:Optional
 	MemberClustersOutpostARNs []*string `json:"memberClustersOutpostARNs,omitempty"`
 	// A flag indicating if you have Multi-AZ enabled to enhance fault tolerance.
 	// For more information, see Minimizing Downtime: Multi-AZ (http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/AutoFailover.html)
+	// +kubebuilder:validation:Optional
 	MultiAZ *string `json:"multiAZ,omitempty"`
 	// A list of node groups in this replication group. For Redis (cluster mode
 	// disabled) replication groups, this is a single-element list. For Redis (cluster
 	// mode enabled) replication groups, the list contains an entry for each node
 	// group (shard).
+	// +kubebuilder:validation:Optional
 	NodeGroups []*NodeGroup `json:"nodeGroups,omitempty"`
 	// A group of settings to be applied to the replication group, either immediately
 	// or during the next maintenance window.
+	// +kubebuilder:validation:Optional
 	PendingModifiedValues *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
 	// The cluster ID that is used as the daily snapshot source for the replication
 	// group.
+	// +kubebuilder:validation:Optional
 	SnapshottingClusterID *string `json:"snapshottingClusterID,omitempty"`
 	// The current state of this replication group - creating, available, modifying,
 	// deleting, create-failed, snapshotting.
+	// +kubebuilder:validation:Optional
 	Status *string `json:"status,omitempty"`
 }
 

--- a/apis/v1alpha1/snapshot.go
+++ b/apis/v1alpha1/snapshot.go
@@ -45,18 +45,23 @@ type SnapshotStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// This parameter is currently disabled.
+	// +kubebuilder:validation:Optional
 	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
 	// Indicates the status of automatic failover for the source Redis replication
 	// group.
+	// +kubebuilder:validation:Optional
 	AutomaticFailover *string `json:"automaticFailover,omitempty"`
 	// The date and time when the source cluster was created.
+	// +kubebuilder:validation:Optional
 	CacheClusterCreateTime *metav1.Time `json:"cacheClusterCreateTime,omitempty"`
 	// The name of the compute and memory capacity node type for the source cluster.
 	//
@@ -103,29 +108,39 @@ type SnapshotStatus struct {
 	//
 	//    * Redis configuration variables appendonly and appendfsync are not supported
 	//    on Redis version 2.8.22 and later.
+	// +kubebuilder:validation:Optional
 	CacheNodeType *string `json:"cacheNodeType,omitempty"`
 	// The cache parameter group that is associated with the source cluster.
+	// +kubebuilder:validation:Optional
 	CacheParameterGroupName *string `json:"cacheParameterGroupName,omitempty"`
 	// The name of the cache subnet group associated with the source cluster.
+	// +kubebuilder:validation:Optional
 	CacheSubnetGroupName *string `json:"cacheSubnetGroupName,omitempty"`
 	// The name of the cache engine (memcached or redis) used by the source cluster.
+	// +kubebuilder:validation:Optional
 	Engine *string `json:"engine,omitempty"`
 	// The version of the cache engine version that is used by the source cluster.
+	// +kubebuilder:validation:Optional
 	EngineVersion *string `json:"engineVersion,omitempty"`
 	// A list of the cache nodes in the source cluster.
+	// +kubebuilder:validation:Optional
 	NodeSnapshots []*NodeSnapshot `json:"nodeSnapshots,omitempty"`
 	// The number of cache nodes in the source cluster.
 	//
 	// For clusters running Redis, this value must be 1. For clusters running Memcached,
 	// this value must be between 1 and 40.
+	// +kubebuilder:validation:Optional
 	NumCacheNodes *int64 `json:"numCacheNodes,omitempty"`
 	// The number of node groups (shards) in this snapshot. When restoring from
 	// a snapshot, the number of node groups (shards) in the snapshot and in the
 	// restored replication group must be the same.
+	// +kubebuilder:validation:Optional
 	NumNodeGroups *int64 `json:"numNodeGroups,omitempty"`
 	// The port number used by each cache nodes in the source cluster.
+	// +kubebuilder:validation:Optional
 	Port *int64 `json:"port,omitempty"`
 	// The name of the Availability Zone in which the source cluster is located.
+	// +kubebuilder:validation:Optional
 	PreferredAvailabilityZone *string `json:"preferredAvailabilityZone,omitempty"`
 	// Specifies the weekly time range during which maintenance on the cluster is
 	// performed. It is specified as a range in the format ddd:hh24:mi-ddd:hh24:mi
@@ -148,10 +163,13 @@ type SnapshotStatus struct {
 	//    * sat
 	//
 	// Example: sun:23:00-mon:01:30
+	// +kubebuilder:validation:Optional
 	PreferredMaintenanceWindow *string `json:"preferredMaintenanceWindow,omitempty"`
 	// The ARN (Amazon Resource Name) of the preferred outpost.
+	// +kubebuilder:validation:Optional
 	PreferredOutpostARN *string `json:"preferredOutpostARN,omitempty"`
 	// A description of the source replication group.
+	// +kubebuilder:validation:Optional
 	ReplicationGroupDescription *string `json:"replicationGroupDescription,omitempty"`
 	// For an automatic snapshot, the number of days for which ElastiCache retains
 	// the snapshot before deleting it.
@@ -163,21 +181,27 @@ type SnapshotStatus struct {
 	//
 	// Important If the value of SnapshotRetentionLimit is set to zero (0), backups
 	// are turned off.
+	// +kubebuilder:validation:Optional
 	SnapshotRetentionLimit *int64 `json:"snapshotRetentionLimit,omitempty"`
 	// Indicates whether the snapshot is from an automatic backup (automated) or
 	// was created manually (manual).
+	// +kubebuilder:validation:Optional
 	SnapshotSource *string `json:"snapshotSource,omitempty"`
 	// The status of the snapshot. Valid values: creating | available | restoring
 	// | copying | deleting.
+	// +kubebuilder:validation:Optional
 	SnapshotStatus *string `json:"snapshotStatus,omitempty"`
 	// The daily time range during which ElastiCache takes daily snapshots of the
 	// source cluster.
+	// +kubebuilder:validation:Optional
 	SnapshotWindow *string `json:"snapshotWindow,omitempty"`
 	// The Amazon Resource Name (ARN) for the topic used by the source cluster for
 	// publishing notifications.
+	// +kubebuilder:validation:Optional
 	TopicARN *string `json:"topicARN,omitempty"`
 	// The Amazon Virtual Private Cloud identifier (VPC ID) of the cache subnet
 	// group for the source cluster.
+	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcID,omitempty"`
 }
 

--- a/apis/v1alpha1/user.go
+++ b/apis/v1alpha1/user.go
@@ -48,21 +48,28 @@ type UserStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// Denotes whether the user requires a password to authenticate.
+	// +kubebuilder:validation:Optional
 	Authentication *Authentication `json:"authentication,omitempty"`
 	// Access permissions string used for this user.
+	// +kubebuilder:validation:Optional
 	ExpandedAccessString *string `json:"expandedAccessString,omitempty"`
 	// Access permissions string used for this user.
+	// +kubebuilder:validation:Optional
 	LastRequestedAccessString *string `json:"lastRequestedAccessString,omitempty"`
 	// Indicates the user status. Can be "active", "modifying" or "deleting".
+	// +kubebuilder:validation:Optional
 	Status *string `json:"status,omitempty"`
 	// Returns a list of the user group IDs the user belongs to.
+	// +kubebuilder:validation:Optional
 	UserGroupIDs []*string `json:"userGroupIDs,omitempty"`
 }
 

--- a/apis/v1alpha1/user_group.go
+++ b/apis/v1alpha1/user_group.go
@@ -39,17 +39,22 @@ type UserGroupStatus struct {
 	// All CRs managed by ACK have a common `Status.ACKResourceMetadata` member
 	// that is used to contain resource sync state, account ownership,
 	// constructed ARN for the resource
+	// +kubebuilder:validation:Optional
 	ACKResourceMetadata *ackv1alpha1.ResourceMetadata `json:"ackResourceMetadata"`
 	// All CRS managed by ACK have a common `Status.Conditions` member that
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
+	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	// A list of updates being applied to the user groups.
+	// +kubebuilder:validation:Optional
 	PendingChanges *UserGroupPendingChanges `json:"pendingChanges,omitempty"`
 	// A list of replication groups that the user group can access.
+	// +kubebuilder:validation:Optional
 	ReplicationGroups []*string `json:"replicationGroups,omitempty"`
 	// Indicates user group status. Can be "creating", "active", "modifying", "deleting".
+	// +kubebuilder:validation:Optional
 	Status *string `json:"status,omitempty"`
 }
 

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2059,11 +2059,6 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 		*out = new(corev1alpha1.SecretKeyReference)
 		**out = **in
 	}
-	if in.AutoMinorVersionUpgrade != nil {
-		in, out := &in.AutoMinorVersionUpgrade, &out.AutoMinorVersionUpgrade
-		*out = new(bool)
-		**out = **in
-	}
 	if in.AutomaticFailoverEnabled != nil {
 		in, out := &in.AutomaticFailoverEnabled, &out.AutomaticFailoverEnabled
 		*out = new(bool)
@@ -2140,11 +2135,6 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 	if in.NotificationTopicARN != nil {
 		in, out := &in.NotificationTopicARN, &out.NotificationTopicARN
 		*out = new(string)
-		**out = **in
-	}
-	if in.NumCacheClusters != nil {
-		in, out := &in.NumCacheClusters, &out.NumCacheClusters
-		*out = new(int64)
 		**out = **in
 	}
 	if in.NumNodeGroups != nil {

--- a/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
@@ -175,9 +175,6 @@ spec:
                       type: string
                   type: object
                 type: array
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -160,9 +160,6 @@ spec:
                 description: The Amazon Virtual Private Cloud identifier (VPC ID)
                   of the cache subnet group.
                 type: string
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -73,9 +73,6 @@ spec:
                 required:
                 - key
                 type: object
-              autoMinorVersionUpgrade:
-                description: This parameter is currently disabled.
-                type: boolean
               automaticFailoverEnabled:
                 description: "Specifies whether a read-only replica is automatically
                   promoted to read/write primary if the existing primary fails. \n
@@ -247,17 +244,6 @@ spec:
                   Notification Service (SNS) topic to which notifications are sent.
                   \n The Amazon SNS topic owner must be the same as the cluster owner."
                 type: string
-              numCacheClusters:
-                description: "The number of clusters this replication group initially
-                  has. \n This parameter is not used if there is more than one node
-                  group (shard). You should use ReplicasPerNodeGroup instead. \n If
-                  AutomaticFailoverEnabled is true, the value of this parameter must
-                  be at least 2. If AutomaticFailoverEnabled is false you can omit
-                  this parameter (it will default to 1), or you can explicitly set
-                  it to a value between 2 and 6. \n The maximum permitted value for
-                  NumCacheClusters is 6 (1 primary plus 5 replicas)."
-                format: int64
-                type: integer
               numNodeGroups:
                 description: "An optional parameter that specifies the number of node
                   groups (shards) for this Redis (cluster mode enabled) replication
@@ -703,9 +689,6 @@ spec:
                 description: The current state of this replication group - creating,
                   available, modifying, deleting, create-failed, snapshotting.
                 type: string
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
@@ -299,9 +299,6 @@ spec:
                 description: The Amazon Virtual Private Cloud identifier (VPC ID)
                   of the cache subnet group for the source cluster.
                 type: string
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
@@ -131,9 +131,6 @@ spec:
                 description: Indicates user group status. Can be "creating", "active",
                   "modifying", "deleting".
                 type: string
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/config/crd/bases/elasticache.services.k8s.aws_users.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_users.yaml
@@ -162,9 +162,6 @@ spec:
                 items:
                   type: string
                 type: array
-            required:
-            - ackResourceMetadata
-            - conditions
             type: object
         type: object
     served: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -222,3 +222,5 @@ ignore:
     - CreateReplicationGroupInput.Tags
     - CreateUserInput.Tags
     - CreateUserGroupInput.Tags
+    - CreateReplicationGroupInput.AutoMinorVersionUpgrade
+    - CreateReplicationGroupInput.NumCacheClusters

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/elasticache-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.6.0
+	github.com/aws-controllers-k8s/runtime v0.7.1
 	github.com/aws/aws-sdk-go v1.38.52
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.6.0 h1:Up9pn9FfItYiItiSdT+FOfHQNKO8oSb5GU8pKH9JF8E=
-github.com/aws-controllers-k8s/runtime v0.6.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.7.1 h1:iA7x1EBVRffg9aI7vhshWXLYkrd0ySw0qDmGG/10FFg=
+github.com/aws-controllers-k8s/runtime v0.7.1/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.52 h1:7NKcUyTG/CyDX835kq04DDNe8vXaJhbGW8ThemHb18A=
 github.com/aws/aws-sdk-go v1.38.52/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/pkg/resource/cache_parameter_group/sdk.go
+++ b/pkg/resource/cache_parameter_group/sdk.go
@@ -281,16 +281,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -418,16 +418,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/pkg/resource/replication_group/custom_update_api.go
+++ b/pkg/resource/replication_group/custom_update_api.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/pkg/errors"
 	"sort"
 
@@ -515,8 +516,7 @@ func (rm *resourceManager) newUpdateShardConfigurationRequestPayload(
 		}
 	} else if decrease {
 		if len(shardsToRetain) == 0 {
-			return nil, fmt.Errorf("Could not determine NodeGroups to retain while preparing for decrease nodegroups. " +
-				"Consider specifying Spec.NodeGroupConfiguration details to resolve this error.")
+			return nil, awserr.New("InvalidParameterValue", "At least one node group should be present.", nil)
 		}
 		res.SetNodeGroupsToRetain(shardsToRetain)
 	}

--- a/pkg/resource/replication_group/delta.go
+++ b/pkg/resource/replication_group/delta.go
@@ -46,13 +46,6 @@ func newResourceDelta(
 			delta.Add("Spec.AuthToken", a.ko.Spec.AuthToken, b.ko.Spec.AuthToken)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.AutoMinorVersionUpgrade, b.ko.Spec.AutoMinorVersionUpgrade) {
-		delta.Add("Spec.AutoMinorVersionUpgrade", a.ko.Spec.AutoMinorVersionUpgrade, b.ko.Spec.AutoMinorVersionUpgrade)
-	} else if a.ko.Spec.AutoMinorVersionUpgrade != nil && b.ko.Spec.AutoMinorVersionUpgrade != nil {
-		if *a.ko.Spec.AutoMinorVersionUpgrade != *b.ko.Spec.AutoMinorVersionUpgrade {
-			delta.Add("Spec.AutoMinorVersionUpgrade", a.ko.Spec.AutoMinorVersionUpgrade, b.ko.Spec.AutoMinorVersionUpgrade)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.AutomaticFailoverEnabled, b.ko.Spec.AutomaticFailoverEnabled) {
 		delta.Add("Spec.AutomaticFailoverEnabled", a.ko.Spec.AutomaticFailoverEnabled, b.ko.Spec.AutomaticFailoverEnabled)
 	} else if a.ko.Spec.AutomaticFailoverEnabled != nil && b.ko.Spec.AutomaticFailoverEnabled != nil {
@@ -120,13 +113,6 @@ func newResourceDelta(
 	} else if a.ko.Spec.NotificationTopicARN != nil && b.ko.Spec.NotificationTopicARN != nil {
 		if *a.ko.Spec.NotificationTopicARN != *b.ko.Spec.NotificationTopicARN {
 			delta.Add("Spec.NotificationTopicARN", a.ko.Spec.NotificationTopicARN, b.ko.Spec.NotificationTopicARN)
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.NumCacheClusters, b.ko.Spec.NumCacheClusters) {
-		delta.Add("Spec.NumCacheClusters", a.ko.Spec.NumCacheClusters, b.ko.Spec.NumCacheClusters)
-	} else if a.ko.Spec.NumCacheClusters != nil && b.ko.Spec.NumCacheClusters != nil {
-		if *a.ko.Spec.NumCacheClusters != *b.ko.Spec.NumCacheClusters {
-			delta.Add("Spec.NumCacheClusters", a.ko.Spec.NumCacheClusters, b.ko.Spec.NumCacheClusters)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.NumNodeGroups, b.ko.Spec.NumNodeGroups) {

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -736,9 +736,6 @@ func (rm *resourceManager) newCreateRequestPayload(
 			res.SetAuthToken(tmpSecret)
 		}
 	}
-	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
-		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
-	}
 	if r.ko.Spec.AutomaticFailoverEnabled != nil {
 		res.SetAutomaticFailoverEnabled(*r.ko.Spec.AutomaticFailoverEnabled)
 	}
@@ -749,13 +746,13 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetCacheParameterGroupName(*r.ko.Spec.CacheParameterGroupName)
 	}
 	if r.ko.Spec.CacheSecurityGroupNames != nil {
-		f6 := []*string{}
-		for _, f6iter := range r.ko.Spec.CacheSecurityGroupNames {
-			var f6elem string
-			f6elem = *f6iter
-			f6 = append(f6, &f6elem)
+		f5 := []*string{}
+		for _, f5iter := range r.ko.Spec.CacheSecurityGroupNames {
+			var f5elem string
+			f5elem = *f5iter
+			f5 = append(f5, &f5elem)
 		}
-		res.SetCacheSecurityGroupNames(f6)
+		res.SetCacheSecurityGroupNames(f5)
 	}
 	if r.ko.Spec.CacheSubnetGroupName != nil {
 		res.SetCacheSubnetGroupName(*r.ko.Spec.CacheSubnetGroupName)
@@ -770,92 +767,89 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetKmsKeyId(*r.ko.Spec.KMSKeyID)
 	}
 	if r.ko.Spec.LogDeliveryConfigurations != nil {
-		f11 := []*svcsdk.LogDeliveryConfigurationRequest{}
-		for _, f11iter := range r.ko.Spec.LogDeliveryConfigurations {
-			f11elem := &svcsdk.LogDeliveryConfigurationRequest{}
-			if f11iter.DestinationDetails != nil {
-				f11elemf0 := &svcsdk.DestinationDetails{}
-				if f11iter.DestinationDetails.CloudWatchLogsDetails != nil {
-					f11elemf0f0 := &svcsdk.CloudWatchLogsDestinationDetails{}
-					if f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
-						f11elemf0f0.SetLogGroup(*f11iter.DestinationDetails.CloudWatchLogsDetails.LogGroup)
+		f10 := []*svcsdk.LogDeliveryConfigurationRequest{}
+		for _, f10iter := range r.ko.Spec.LogDeliveryConfigurations {
+			f10elem := &svcsdk.LogDeliveryConfigurationRequest{}
+			if f10iter.DestinationDetails != nil {
+				f10elemf0 := &svcsdk.DestinationDetails{}
+				if f10iter.DestinationDetails.CloudWatchLogsDetails != nil {
+					f10elemf0f0 := &svcsdk.CloudWatchLogsDestinationDetails{}
+					if f10iter.DestinationDetails.CloudWatchLogsDetails.LogGroup != nil {
+						f10elemf0f0.SetLogGroup(*f10iter.DestinationDetails.CloudWatchLogsDetails.LogGroup)
 					}
-					f11elemf0.SetCloudWatchLogsDetails(f11elemf0f0)
+					f10elemf0.SetCloudWatchLogsDetails(f10elemf0f0)
 				}
-				if f11iter.DestinationDetails.KinesisFirehoseDetails != nil {
-					f11elemf0f1 := &svcsdk.KinesisFirehoseDestinationDetails{}
-					if f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
-						f11elemf0f1.SetDeliveryStream(*f11iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
+				if f10iter.DestinationDetails.KinesisFirehoseDetails != nil {
+					f10elemf0f1 := &svcsdk.KinesisFirehoseDestinationDetails{}
+					if f10iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream != nil {
+						f10elemf0f1.SetDeliveryStream(*f10iter.DestinationDetails.KinesisFirehoseDetails.DeliveryStream)
 					}
-					f11elemf0.SetKinesisFirehoseDetails(f11elemf0f1)
+					f10elemf0.SetKinesisFirehoseDetails(f10elemf0f1)
 				}
-				f11elem.SetDestinationDetails(f11elemf0)
+				f10elem.SetDestinationDetails(f10elemf0)
 			}
-			if f11iter.DestinationType != nil {
-				f11elem.SetDestinationType(*f11iter.DestinationType)
+			if f10iter.DestinationType != nil {
+				f10elem.SetDestinationType(*f10iter.DestinationType)
 			}
-			if f11iter.Enabled != nil {
-				f11elem.SetEnabled(*f11iter.Enabled)
+			if f10iter.Enabled != nil {
+				f10elem.SetEnabled(*f10iter.Enabled)
 			}
-			if f11iter.LogFormat != nil {
-				f11elem.SetLogFormat(*f11iter.LogFormat)
+			if f10iter.LogFormat != nil {
+				f10elem.SetLogFormat(*f10iter.LogFormat)
 			}
-			if f11iter.LogType != nil {
-				f11elem.SetLogType(*f11iter.LogType)
+			if f10iter.LogType != nil {
+				f10elem.SetLogType(*f10iter.LogType)
 			}
-			f11 = append(f11, f11elem)
+			f10 = append(f10, f10elem)
 		}
-		res.SetLogDeliveryConfigurations(f11)
+		res.SetLogDeliveryConfigurations(f10)
 	}
 	if r.ko.Spec.MultiAZEnabled != nil {
 		res.SetMultiAZEnabled(*r.ko.Spec.MultiAZEnabled)
 	}
 	if r.ko.Spec.NodeGroupConfiguration != nil {
-		f13 := []*svcsdk.NodeGroupConfiguration{}
-		for _, f13iter := range r.ko.Spec.NodeGroupConfiguration {
-			f13elem := &svcsdk.NodeGroupConfiguration{}
-			if f13iter.NodeGroupID != nil {
-				f13elem.SetNodeGroupId(*f13iter.NodeGroupID)
+		f12 := []*svcsdk.NodeGroupConfiguration{}
+		for _, f12iter := range r.ko.Spec.NodeGroupConfiguration {
+			f12elem := &svcsdk.NodeGroupConfiguration{}
+			if f12iter.NodeGroupID != nil {
+				f12elem.SetNodeGroupId(*f12iter.NodeGroupID)
 			}
-			if f13iter.PrimaryAvailabilityZone != nil {
-				f13elem.SetPrimaryAvailabilityZone(*f13iter.PrimaryAvailabilityZone)
+			if f12iter.PrimaryAvailabilityZone != nil {
+				f12elem.SetPrimaryAvailabilityZone(*f12iter.PrimaryAvailabilityZone)
 			}
-			if f13iter.PrimaryOutpostARN != nil {
-				f13elem.SetPrimaryOutpostArn(*f13iter.PrimaryOutpostARN)
+			if f12iter.PrimaryOutpostARN != nil {
+				f12elem.SetPrimaryOutpostArn(*f12iter.PrimaryOutpostARN)
 			}
-			if f13iter.ReplicaAvailabilityZones != nil {
-				f13elemf3 := []*string{}
-				for _, f13elemf3iter := range f13iter.ReplicaAvailabilityZones {
-					var f13elemf3elem string
-					f13elemf3elem = *f13elemf3iter
-					f13elemf3 = append(f13elemf3, &f13elemf3elem)
+			if f12iter.ReplicaAvailabilityZones != nil {
+				f12elemf3 := []*string{}
+				for _, f12elemf3iter := range f12iter.ReplicaAvailabilityZones {
+					var f12elemf3elem string
+					f12elemf3elem = *f12elemf3iter
+					f12elemf3 = append(f12elemf3, &f12elemf3elem)
 				}
-				f13elem.SetReplicaAvailabilityZones(f13elemf3)
+				f12elem.SetReplicaAvailabilityZones(f12elemf3)
 			}
-			if f13iter.ReplicaCount != nil {
-				f13elem.SetReplicaCount(*f13iter.ReplicaCount)
+			if f12iter.ReplicaCount != nil {
+				f12elem.SetReplicaCount(*f12iter.ReplicaCount)
 			}
-			if f13iter.ReplicaOutpostARNs != nil {
-				f13elemf5 := []*string{}
-				for _, f13elemf5iter := range f13iter.ReplicaOutpostARNs {
-					var f13elemf5elem string
-					f13elemf5elem = *f13elemf5iter
-					f13elemf5 = append(f13elemf5, &f13elemf5elem)
+			if f12iter.ReplicaOutpostARNs != nil {
+				f12elemf5 := []*string{}
+				for _, f12elemf5iter := range f12iter.ReplicaOutpostARNs {
+					var f12elemf5elem string
+					f12elemf5elem = *f12elemf5iter
+					f12elemf5 = append(f12elemf5, &f12elemf5elem)
 				}
-				f13elem.SetReplicaOutpostArns(f13elemf5)
+				f12elem.SetReplicaOutpostArns(f12elemf5)
 			}
-			if f13iter.Slots != nil {
-				f13elem.SetSlots(*f13iter.Slots)
+			if f12iter.Slots != nil {
+				f12elem.SetSlots(*f12iter.Slots)
 			}
-			f13 = append(f13, f13elem)
+			f12 = append(f12, f12elem)
 		}
-		res.SetNodeGroupConfiguration(f13)
+		res.SetNodeGroupConfiguration(f12)
 	}
 	if r.ko.Spec.NotificationTopicARN != nil {
 		res.SetNotificationTopicArn(*r.ko.Spec.NotificationTopicARN)
-	}
-	if r.ko.Spec.NumCacheClusters != nil {
-		res.SetNumCacheClusters(*r.ko.Spec.NumCacheClusters)
 	}
 	if r.ko.Spec.NumNodeGroups != nil {
 		res.SetNumNodeGroups(*r.ko.Spec.NumNodeGroups)
@@ -864,13 +858,13 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetPort(*r.ko.Spec.Port)
 	}
 	if r.ko.Spec.PreferredCacheClusterAZs != nil {
-		f18 := []*string{}
-		for _, f18iter := range r.ko.Spec.PreferredCacheClusterAZs {
-			var f18elem string
-			f18elem = *f18iter
-			f18 = append(f18, &f18elem)
+		f16 := []*string{}
+		for _, f16iter := range r.ko.Spec.PreferredCacheClusterAZs {
+			var f16elem string
+			f16elem = *f16iter
+			f16 = append(f16, &f16elem)
 		}
-		res.SetPreferredCacheClusterAZs(f18)
+		res.SetPreferredCacheClusterAZs(f16)
 	}
 	if r.ko.Spec.PreferredMaintenanceWindow != nil {
 		res.SetPreferredMaintenanceWindow(*r.ko.Spec.PreferredMaintenanceWindow)
@@ -888,22 +882,22 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
 	}
 	if r.ko.Spec.SecurityGroupIDs != nil {
-		f24 := []*string{}
-		for _, f24iter := range r.ko.Spec.SecurityGroupIDs {
-			var f24elem string
-			f24elem = *f24iter
-			f24 = append(f24, &f24elem)
+		f22 := []*string{}
+		for _, f22iter := range r.ko.Spec.SecurityGroupIDs {
+			var f22elem string
+			f22elem = *f22iter
+			f22 = append(f22, &f22elem)
 		}
-		res.SetSecurityGroupIds(f24)
+		res.SetSecurityGroupIds(f22)
 	}
 	if r.ko.Spec.SnapshotARNs != nil {
-		f25 := []*string{}
-		for _, f25iter := range r.ko.Spec.SnapshotARNs {
-			var f25elem string
-			f25elem = *f25iter
-			f25 = append(f25, &f25elem)
+		f23 := []*string{}
+		for _, f23iter := range r.ko.Spec.SnapshotARNs {
+			var f23elem string
+			f23elem = *f23iter
+			f23 = append(f23, &f23elem)
 		}
-		res.SetSnapshotArns(f25)
+		res.SetSnapshotArns(f23)
 	}
 	if r.ko.Spec.SnapshotName != nil {
 		res.SetSnapshotName(*r.ko.Spec.SnapshotName)
@@ -918,13 +912,13 @@ func (rm *resourceManager) newCreateRequestPayload(
 		res.SetTransitEncryptionEnabled(*r.ko.Spec.TransitEncryptionEnabled)
 	}
 	if r.ko.Spec.UserGroupIDs != nil {
-		f30 := []*string{}
-		for _, f30iter := range r.ko.Spec.UserGroupIDs {
-			var f30elem string
-			f30elem = *f30iter
-			f30 = append(f30, &f30elem)
+		f28 := []*string{}
+		for _, f28iter := range r.ko.Spec.UserGroupIDs {
+			var f28elem string
+			f28elem = *f28iter
+			f28 = append(f28, &f28elem)
 		}
-		res.SetUserGroupIds(f30)
+		res.SetUserGroupIds(f28)
 	}
 
 	return res, nil
@@ -1287,9 +1281,6 @@ func (rm *resourceManager) newUpdateRequestPayload(
 			res.SetAuthToken(tmpSecret)
 		}
 	}
-	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
-		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
-	}
 	if r.ko.Spec.AutomaticFailoverEnabled != nil {
 		res.SetAutomaticFailoverEnabled(*r.ko.Spec.AutomaticFailoverEnabled)
 	}
@@ -1461,16 +1452,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -623,16 +623,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -434,16 +434,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/pkg/resource/user_group/sdk.go
+++ b/pkg/resource/user_group/sdk.go
@@ -363,16 +363,21 @@ func (rm *resourceManager) updateConditions(
 		}
 	}
 
-	if rm.terminalAWSError(err) {
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
 			}
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
+		var errorMessage = ""
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+			errorMessage = err.Error()
+		} else {
+			awsErr, _ := ackerr.AWSError(err)
+			errorMessage = awsErr.Message()
+		}
 		terminalCondition.Status = corev1.ConditionTrue
-		awsErr, _ := ackerr.AWSError(err)
-		errorMessage := awsErr.Message()
 		terminalCondition.Message = &errorMessage
 	} else {
 		// Clear the terminal condition if no longer present

--- a/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
@@ -8,7 +8,8 @@ spec:
   replicationGroupDescription: test replication group for input field coverage
   replicationGroupID: $RG_ID
   snapshotName: $SNAPSHOT_NAME
-  numCacheClusters: 3
+  numNodeGroups: 1
+  replicasPerNodeGroup: 2
   preferredCacheClusterAZs:
     - us-west-2a
     - us-west-2b


### PR DESCRIPTION
- Secret issues to be terminal conditions.
- Updated runtime
- New code with updated code generator
- Removed AutoMinorVersionUpgrade and NumCacheClusters
- Updated an error and error message to be terminal condition

#### Secret not found
```
 Conditions:
    Message:  kubernetes secret not found
    Status:   True
    Type:     ACK.Terminal
```

#### Negative node group
```
  Conditions:
    Message:    At least one node group should be present.
    Status:     True
    Type:       ACK.Terminal
    Status:     True
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
