### PR TITLE
Replication group: cluster mode disabled test for spec update

### DIFF
--- a/pkg/resource/replication_group/testdata/allowed_node_types/read_many/rg_cmd_allowed_node_types_simple.json
+++ b/pkg/resource/replication_group/testdata/allowed_node_types/read_many/rg_cmd_allowed_node_types_simple.json
@@ -1,0 +1,5 @@
+{
+  "ScaleUpModifications": [
+    "cache.m3.2xlarge"
+  ]
+}

--- a/pkg/resource/replication_group/testdata/cache_clusters/read_many/rg_cmd_all_spec.json
+++ b/pkg/resource/replication_group/testdata/cache_clusters/read_many/rg_cmd_all_spec.json
@@ -1,0 +1,46 @@
+{
+  "CacheClusters": [
+    {
+      "CacheClusterId": "rg-all-spec-001",
+      "ReplicationGroupId": "rg-all-spec",
+      "CacheClusterStatus": "available",
+      "SnapshotRetentionLimit": 0,
+      "ClientDownloadLandingPage": "https://console.aws.amazon.com/elasticache/home#client-download:",
+      "CacheNodeType": "cache.t3.micro",
+      "TransitEncryptionEnabled": false,
+      "Engine": "mock-engine",
+      "CacheSecurityGroups": [],
+      "NumCacheNodes": 1,
+      "AutoMinorVersionUpgrade": true,
+      "SecurityGroups": [
+        {
+          "Status": "active",
+          "SecurityGroupId": "sgid3"
+        },
+        {
+          "Status": "active",
+          "SecurityGroupId": "sgid4"
+        }
+      ],
+      "PendingModifiedValues": {},
+      "PreferredMaintenanceWindow": "wed:08:00-wed:09:00",
+      "CacheSubnetGroupName": "non-default-subnet-group",
+      "AuthTokenEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "EngineVersion": "6.0.5",
+      "CacheClusterCreateTime": "2021-04-13T19:07:04.983Z",
+      "PreferredAvailabilityZone": "us-west-2c",
+      "SnapshotWindow": "06:30-07:30",
+      "NotificationConfiguration": {
+        "TopicStatus": "active",
+        "TopicArn": "arn:aws:sns:mock-arn-2"
+      },
+      "ARN": "arn:aws:elasticache:us-east-1:012345678910:cluster:rg-all-spec-001",
+      "CacheParameterGroup": {
+        "CacheNodeIdsToReboot": [],
+        "CacheParameterGroupName": "customparamgroup",
+        "ParameterApplyStatus": "in-sync"
+      }
+    }
+  ]
+}

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_all_spec_desired.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_all_spec_desired.yaml
@@ -1,0 +1,108 @@
+# This manifest is not realistic. For example, specifying both CacheSecurityGroupNames and SecurityGroupIDs is
+#   redundant, and there are many other invalid parameter combinations. Further, many of these creation (Spec) fields
+#   are immutable and practically will never see a value from the server different than the one specified upon creation.
+#   However, the purpose of this test is to ensure that for every spec field, the latest object will have the
+#   correct state from the API response, as opposed to merely being copied over from the desired object.
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: rg-all-spec
+spec:
+  atRestEncryptionEnabled: true
+  authToken:
+    namespace: default
+    name: first
+    key: secret1
+  automaticFailoverEnabled: true
+  cacheNodeType: cache.t3.small
+  cacheParameterGroupName: default.redis6.x.cluster.on
+  cacheSecurityGroupNames:
+    - sgname1
+    - sgname2
+  cacheSubnetGroupName: default
+  engine: redis
+  engineVersion: 6.x
+  kmsKeyID: key1
+  logDeliveryConfigurations:
+    - destinationType: cloudwatch-logs
+      logFormat: json
+      logType: slow-log
+      destinationDetails:
+        cloudWatchLogsDetails:
+          logGroup: log-group-1
+  multiAZEnabled: true
+  nodeGroupConfiguration:
+    - nodeGroupID: "0001"
+      primaryAvailabilityZone: us-west-2a
+      replicaAvailabilityZones:
+        - us-west-2b
+      replicaCount: 5
+  notificationTopicARN: arn:aws:sns:mock-arn-1
+  numNodeGroups: 2
+  port: 6380
+  preferredCacheClusterAZs:
+    - us-west-2a
+    - us-west-2b
+  preferredMaintenanceWindow: sun:23:00-mon:01:30
+  primaryClusterID: primary1
+  replicasPerNodeGroup: 5
+  replicationGroupDescription: description1
+  replicationGroupID: rg-all-spec
+  securityGroupIDs:
+    - sgid1
+    - sgid2
+  snapshotARNs:
+    - mock-arn-1
+  snapshotName: snapshot1
+  snapshotRetentionLimit: 5
+  snapshotWindow: 05:00-06:00
+  transitEncryptionEnabled: true
+  userGroupIDs:
+    - usergroup1
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-west-2:012345678910:replicationgroup:rg-all-spec
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+  authTokenEnabled: false
+  automaticFailover: enabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: description1
+  events: # RG name is inconsistent but this test focuses on spec, not status
+    - date: "2021-03-30T20:12:00Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  memberClusters:
+    - rg-cmd-001
+    - rg-cmd-002
+  multiAZ: enabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-all-spec-001
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-west-2a
+          readEndpoint:
+            address: primary-address-1
+            port: 6380
+        - cacheClusterID: rg-all-spec-002
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-west-2b
+          readEndpoint:
+            address: replica-address-1
+            port: 6380
+      primaryEndpoint:
+        address: cluster-address-1
+        port: 6380
+      readerEndpoint:
+        address: reader-address-1
+        port: 6380
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_all_spec_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_all_spec_latest.yaml
@@ -1,0 +1,110 @@
+# see rg_cmd_all_spec_desired.yaml for more details. Almost all spec fields in this
+# file are different from those in that file.
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: rg-all-spec
+spec:
+  atRestEncryptionEnabled: false
+  # authToken is not retrievable by the server, so should not be present here
+  automaticFailoverEnabled: false
+  cacheNodeType: cache.t3.micro
+  cacheParameterGroupName: customparamgroup
+  cacheSecurityGroupNames:
+    - sgname3
+    - sgname4
+  cacheSubnetGroupName: non-default-subnet-group
+  engine: mock-engine
+  engineVersion: 6.0.5
+  kmsKeyID: key2 # included even though the API has not been returning the associated field
+  logDeliveryConfigurations:
+    - destinationType: kinesis-firehose
+      logFormat: text
+      logType: slow-log
+      destinationDetails:
+        kinesisFirehoseDetails:
+          deliveryStream: test
+  multiAZEnabled: false
+  nodeGroupConfiguration:
+    - nodeGroupID: "0001"
+      primaryAvailabilityZone: us-west-2d
+      replicaAvailabilityZones:
+        - us-west-2c
+      replicaCount: 1
+  notificationTopicARN: arn:aws:sns:mock-arn-2
+  numNodeGroups: 1
+  port: 7070
+  preferredCacheClusterAZs:
+    - us-west-2d
+    - us-west-2c
+  preferredMaintenanceWindow: wed:08:00-wed:09:00
+  primaryClusterID: rg-all-spec-002
+  replicasPerNodeGroup: 1
+  replicationGroupDescription: description2
+  replicationGroupID: rg-all-spec
+  securityGroupIDs:
+    - sgid3
+    - sgid4
+  # snapshotARNs should not be present; see note about authToken above
+  # snapshotName should not be present, same case as above
+  snapshotRetentionLimit: 0
+  snapshotWindow: 10:00-11:00
+  transitEncryptionEnabled: false
+  userGroupIDs:
+    - usergroup2
+status:
+  ackResourceMetadata:
+    arn: arn:aws:elasticache:us-west-2:012345678910:replicationgroup:rg-all-spec
+    ownerAccountID: ""
+  allowedScaleUpModifications:
+    - cache.m3.2xlarge
+  authTokenEnabled: false
+  automaticFailover: disabled
+  clusterEnabled: false
+  conditions:
+    - status: "True"
+      type: ACK.ResourceSynced
+  description: description2
+  events: # should remain same as in desired
+    - date: "2021-03-30T20:12:00Z"
+      message: Replication group rg-cmd created
+  globalReplicationGroupInfo: {}
+  logDeliveryConfigurations:
+    - destinationType: kinesis-firehose
+      logFormat: text
+      logType: slow-log
+      message: "Destination delivery stream test does not exist."
+      status: error
+      destinationDetails:
+        kinesisFirehoseDetails:
+          deliveryStream: test
+  memberClusters:
+    - rg-all-spec-001
+    - rg-all-spec-002
+  multiAZ: disabled
+  nodeGroups:
+    - nodeGroupID: "0001"
+      nodeGroupMembers:
+        - cacheClusterID: rg-all-spec-001
+          cacheNodeID: "0001"
+          currentRole: replica
+          preferredAvailabilityZone: us-west-2c
+          readEndpoint:
+            address: replica-address-2
+            port: 7070
+        - cacheClusterID: rg-all-spec-002
+          cacheNodeID: "0001"
+          currentRole: primary
+          preferredAvailabilityZone: us-west-2d
+          readEndpoint:
+            address: primary-address-2
+            port: 7070
+      primaryEndpoint:
+        address: cluster-address-2
+        port: 7070
+      readerEndpoint:
+        address: reader-address-2
+        port: 7070
+      status: available
+  pendingModifiedValues: {}
+  status: available

--- a/pkg/resource/replication_group/testdata/replication_group/read_one/rg_cmd_all_spec.json
+++ b/pkg/resource/replication_group/testdata/replication_group/read_one/rg_cmd_all_spec.json
@@ -1,0 +1,79 @@
+{
+  "ReplicationGroups": [
+    {
+      "Status": "available",
+      "MultiAZ": "disabled",
+      "Description": "description2",
+      "UserGroupIds": [
+        "usergroup2"
+      ],
+      "NodeGroups": [
+        {
+          "Status": "available",
+          "NodeGroupMembers": [
+            {
+              "CurrentRole": "replica",
+              "PreferredAvailabilityZone": "us-west-2c",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Port": 7070,
+                "Address": "replica-address-2"
+              },
+              "CacheClusterId": "rg-all-spec-001"
+            },
+            {
+              "CurrentRole": "primary",
+              "PreferredAvailabilityZone": "us-west-2d",
+              "CacheNodeId": "0001",
+              "ReadEndpoint": {
+                "Port": 7070,
+                "Address": "primary-address-2"
+              },
+              "CacheClusterId": "rg-all-spec-002"
+            }
+          ],
+          "ReaderEndpoint": {
+            "Port": 7070,
+            "Address": "reader-address-1"
+          },
+          "NodeGroupId": "0001",
+          "PrimaryEndpoint": {
+            "Port": 7070,
+            "Address": "cluster-address-2"
+          }
+        }
+      ],
+      "AuthTokenEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "ClusterEnabled": false,
+      "LogDeliveryConfigurations": [
+        {
+          "DestinationDetails": {
+            "KinesisFirehoseDetails": {
+              "DeliveryStream": "test"
+            }
+          },
+          "Status": "error",
+          "LogType": "slow-log",
+          "LogFormat": "text",
+          "DestinationType": "kinesis-firehose",
+          "Message": "Destination delivery stream test does not exist."
+        }
+      ],
+      "ReplicationGroupId": "rg-all-spec",
+      "GlobalReplicationGroupInfo": {},
+      "SnapshotRetentionLimit": 0,
+      "AutomaticFailover": "disabled",
+      "TransitEncryptionEnabled": false,
+      "SnapshotWindow": "10:00-11:00",
+      "KmsKeyId": "key2",
+      "MemberClusters": [
+        "rg-all-spec-001",
+        "rg-all-spec-002"
+      ],
+      "CacheNodeType": "cache.t3.micro",
+      "ARN": "arn:aws:elasticache:us-west-2:012345678910:replicationgroup:rg-all-spec",
+      "PendingModifiedValues": {}
+    }
+  ]
+}

--- a/pkg/resource/replication_group/testdata/test_suite.yaml
+++ b/pkg/resource/replication_group/testdata/test_suite.yaml
@@ -72,6 +72,23 @@ tests:
         expect:
           latest_state: "replication_group/cr/rg_cmd_create_completed.yaml" #unchanged
           error: nil
+      - name: "ReadOne=SpecUpdate"
+        description: "Test if the controller can populate the latest resource Spec with updated values from the server."
+        given:
+          desired_state: "replication_group/cr/rg_cmd_all_spec_desired.yaml"
+          svc_api:
+            - operation: DescribeReplicationGroupsWithContext
+              output_fixture: "replication_group/read_one/rg_cmd_all_spec.json"
+            - operation: DescribeCacheClustersWithContext
+              output_fixture: "cache_clusters/read_many/rg_cmd_all_spec.json"
+            - operation: ListAllowedNodeTypeModifications
+              output_fixture: "allowed_node_types/read_many/rg_cmd_allowed_node_types_simple.json"
+            - operation: DescribeEventsWithContext
+              output_fixture: "events/read_many/rg_cmd_events.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "replication_group/cr/rg_cmd_all_spec_latest.yaml"
+          error: nil
       - name: "Update=IncreaseReplicaCount"
         description: "Ensure a replica is added once a new config is provided"
         given:


### PR DESCRIPTION
The purpose of this test is to evaluate whether the controller can take the API responses from the ElastiCache describe APIs called during `ReadOne` and map them to the latest object's Spec.

A reliable record of the object's latest state is necessary to taking the correct action in updating the resource (or leaving it as-is).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
