### PR TITLE
Fix image reference in Helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: public.ecr.aws/aws-controllers-k8s/controller
-  tag: elasticache-v0.0.4
+  repository: public.ecr.aws/aws-controllers-k8s/elasticache-controller
+  tag: v0.0.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:

The public.ecr.aws/aws-controllers-k8s/controller repository is [deprecated](https://gallery.ecr.aws/aws-controllers-k8s/controller), and the elasticache-v0.0.4 tag doesn't exist.

This PR updates the default image repository to public.ecr.aws/aws-controllers-k8s/elasticache-controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
