### PR TITLE
Add CacheClusterNotFound terminal code

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-09-13T18:13:33Z"
-  build_hash: c6e8ce29423336f827d2ca5c737595561c84539c
+  build_date: "2021-09-16T23:00:17Z"
+  build_hash: e4d2ea41769ef5eda245946f462ef7c1c6840409
   go_version: go1.15.2
-  version: v0.13.2
+  version: v0.14.0
 api_directory_checksum: 69c917d1e1ee2b196c23799a02417b920297bc74
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.52
 generator_config_info:
-  file_checksum: 68bcd4be3880f0774c1a4b02a56da6caff19a87e
+  file_checksum: 261e03a6b9fb25805b045293947f13e5674d2924
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -36,6 +36,7 @@ resources:
         - InvalidCacheSecurityGroupState
         - CacheParameterGroupNotFound
         - InvalidKMSKeyFault
+        - CacheClusterNotFound
     fields:
       AllowedScaleUpModifications:
         is_read_only: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -36,6 +36,7 @@ resources:
         - InvalidCacheSecurityGroupState
         - CacheParameterGroupNotFound
         - InvalidKMSKeyFault
+        - CacheClusterNotFound
     fields:
       AllowedScaleUpModifications:
         is_read_only: true

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "app.fullname" . }}-metrics
+  name: {{ .Chart.Name | trimSuffix "-chart" | trunc 44 }}-controller-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "app.name" . }}

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -1807,7 +1807,8 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"NodeGroupsPerReplicationGroupQuotaExceeded",
 		"InvalidCacheSecurityGroupState",
 		"CacheParameterGroupNotFound",
-		"InvalidKMSKeyFault":
+		"InvalidKMSKeyFault",
+		"CacheClusterNotFound":
 		return true
 	default:
 		return false

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -402,7 +402,6 @@ class TestReplicationGroup:
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
 
     # if primaryClusterID is a nonexistent node, the terminal condition should be set
-    @pytest.mark.blocked  # TODO: remove when passing
     def test_rg_invalid_primary(self, rg_invalid_primary):
         (reference, _) = rg_invalid_primary
         sleep(DEFAULT_WAIT_SECS)


### PR DESCRIPTION
This fixes the failing negative scenario where we attempt to create a replication group with a `primaryClusterID` of a node that doesn't exist. Removed the skip marker from the test as it passes locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
