### PR TITLE
fixes to log delivery modification

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-10-12T16:29:01Z"
-  build_hash: 4b30ff5578e2f570d1c5b1741f3098be0d78e246
-  go_version: go1.16.5
+  build_date: "2021-10-14T18:44:40Z"
+  build_hash: 385779a205bea50e8762b76bc75cab957cf723b9
+  go_version: go1.15.2
   version: v0.15.1
-api_directory_checksum: 69c917d1e1ee2b196c23799a02417b920297bc74
+api_directory_checksum: 8e4808b17b3a814f0a624eee8d68a0b45ba5e2c4
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.52
 generator_config_info:
-  file_checksum: 261e03a6b9fb25805b045293947f13e5674d2924
+  file_checksum: 28e3cd3119df8028a65eb0729a462b4354d27fa9
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/annotations.go
+++ b/apis/v1alpha1/annotations.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+const (
+	// AnnotationPrefix is the prefix for all annotations specifically for
+	// the elasticache service.
+	AnnotationPrefix = "elasticache.services.k8s.aws/"
+)

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -56,10 +56,12 @@ resources:
       AuthToken:
         is_secret: true
       LogDeliveryConfigurations:
-        is_read_only: true
+        is_read_only: true # creates an additional status field of the same name
         from:
           operation: CreateReplicationGroup
           path: ReplicationGroup.LogDeliveryConfigurations
+        compare: # removes the spec field from automatic delta comparison
+          is_ignored: true
     hooks:
       sdk_read_many_post_set_output:
         template_path: hooks/replication_group/sdk_read_many_post_set_output.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -56,10 +56,12 @@ resources:
       AuthToken:
         is_secret: true
       LogDeliveryConfigurations:
-        is_read_only: true
+        is_read_only: true # creates an additional status field of the same name
         from:
           operation: CreateReplicationGroup
           path: ReplicationGroup.LogDeliveryConfigurations
+        compare: # removes the spec field from automatic delta comparison
+          is_ignored: true
     hooks:
       sdk_read_many_post_set_output:
         template_path: hooks/replication_group/sdk_read_many_post_set_output.go.tpl

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: AWS_ACCOUNT_ID
+          value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,7 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
+  account_id: ""
   endpoint_url: ""
 
 # log level for the controller

--- a/pkg/resource/replication_group/annotations.go
+++ b/pkg/resource/replication_group/annotations.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replication_group
+
+import (
+	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
+)
+
+const (
+	// AnnotationLastRequestedLDCs is an annotation whose value is the marshaled list of pointers to
+	// LogDeliveryConfigurationRequest structs passed in as input to either the create or modify API called most
+	// recently
+	AnnotationLastRequestedLDCs = svcapitypes.AnnotationPrefix + "last-requested-log-delivery-configurations"
+)

--- a/pkg/resource/replication_group/delta.go
+++ b/pkg/resource/replication_group/delta.go
@@ -107,9 +107,6 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.LogDeliveryConfigurations, b.ko.Spec.LogDeliveryConfigurations) {
-		delta.Add("Spec.LogDeliveryConfigurations", a.ko.Spec.LogDeliveryConfigurations, b.ko.Spec.LogDeliveryConfigurations)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MultiAZEnabled, b.ko.Spec.MultiAZEnabled) {
 		delta.Add("Spec.MultiAZEnabled", a.ko.Spec.MultiAZEnabled, b.ko.Spec.MultiAZEnabled)
 	} else if a.ko.Spec.MultiAZEnabled != nil && b.ko.Spec.MultiAZEnabled != nil {


### PR DESCRIPTION
### Problem 1: log delivery status is not in sync with replication group status

This was fixed by moving the population of `Status.LogDeliveryConfigurations` to execute after each of Create, Update, and Describe (instead of just Describe). See changes in `custom_set_output.go`.

### Problem 2: stale state from modify API merged into `desired` upon spec patching

This was causing the desired and latest state to infinitely swap. Solution: re-copy `LogDeliveryConfigurations` from `desired.Spec` to `latest.Spec` after the modify API response is merged in to ensure spec patching has no effect on this field. See changes in `custom_set_output.go`.

 https://github.com/aws-controllers-k8s/code-generator/pull/201 was an alternate solution but we were recommended to avoid doing something like this.

### Problem 3: Controller attempts to act on diff when log delivery is disabled

Solution: added in a few lines in `filterDelta` to remove the diff if log delivery is disabled and the API response is `nil`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
