### PR TITLE
Update sdk_file_end.go.tpl to not use OutputShape name for hook method

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2021-09-23T18:08:08Z"
-  build_hash: fe3ca1f5ee52a0e49be0f8458b4e5058a8f0fd47
-  go_version: go1.15
-  version: v0.14.1
+  build_date: "2021-10-11T21:10:37Z"
+  build_hash: 4b30ff5578e2f570d1c5b1741f3098be0d78e246
+  go_version: go1.16.5
+  version: v0.15.1
 api_directory_checksum: 69c917d1e1ee2b196c23799a02417b920297bc74
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.52

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -26,8 +26,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --enable-development-logging

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/elasticache-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.14.1
+	github.com/aws-controllers-k8s/runtime v0.15.1
 	github.com/aws/aws-sdk-go v1.38.52
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.14.1 h1:2/hCwost9rmtgsgktCtJH75U74ziWiBs0bHFOB2iaKo=
-github.com/aws-controllers-k8s/runtime v0.14.1/go.mod h1:kG2WM4JAmLgf67cgZV9IZUkY2DsrUzsaNbmhFMfb05c=
+github.com/aws-controllers-k8s/runtime v0.15.1 h1:3P+6MKWe8ITJynmoxmDnMPlkoI9nuVgn8XD9Pt/XHE8=
+github.com/aws-controllers-k8s/runtime v0.15.1/go.mod h1:W0Txdhb1Npx5kg72w2WFwIpGFvSsMxXlJzzNHAwCLeY=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.52 h1:7NKcUyTG/CyDX835kq04DDNe8vXaJhbGW8ThemHb18A=
 github.com/aws/aws-sdk-go v1.38.52/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
@@ -177,6 +177,8 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jaypipes/envutil v1.0.0 h1:u6Vwy9HwruFihoZrL0bxDLCa/YNadGVwKyPElNmZWow=
+github.com/jaypipes/envutil v1.0.0/go.mod h1:vgIRDly+xgBq0eeZRcflOHMMobMwgC6MkMbxo/Nw65M=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,8 +37,6 @@ spec:
       - command:
         - ./bin/controller
         args:
-        - --aws-account-id
-        - "$(AWS_ACCOUNT_ID)"
         - --aws-region
         - "$(AWS_REGION)"
         - --aws-endpoint-url
@@ -63,8 +61,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: AWS_ACCOUNT_ID
-          value: {{ .Values.aws.account_id | quote }}
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,7 +38,6 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
-  account_id: ""
   endpoint_url: ""
 
 # log level for the controller

--- a/pkg/resource/cache_parameter_group/descriptor.go
+++ b/pkg/resource/cache_parameter_group/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("cacheparametergroups")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "CacheParameterGroup",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/cache_subnet_group/descriptor.go
+++ b/pkg/resource/cache_subnet_group/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("cachesubnetgroups")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "CacheSubnetGroup",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/replication_group/custom_update_api.go
+++ b/pkg/resource/replication_group/custom_update_api.go
@@ -522,7 +522,7 @@ func (rm *resourceManager) newUpdateShardConfigurationRequestPayload(
 			shardsConfig = append(shardsConfig, shardConfig)
 		}
 	} else if decrease {
-		for i := 0;  i < int(*desiredShardsCount); i++ {
+		for i := 0; i < int(*desiredShardsCount); i++ {
 			shardsToRetain = append(shardsToRetain, desired.ko.Status.NodeGroups[i].NodeGroupID)
 		}
 	}

--- a/pkg/resource/replication_group/custom_update_api_test.go
+++ b/pkg/resource/replication_group/custom_update_api_test.go
@@ -392,7 +392,7 @@ func TestCustomModifyReplicationGroup_NodeGroup_available(t *testing.T) {
 	})
 }
 
-func TestCustomModifyReplicationGroup_ScaleUpAndDown_And_Resharding(t *testing.T)  {
+func TestCustomModifyReplicationGroup_ScaleUpAndDown_And_Resharding(t *testing.T) {
 	assert := assert.New(t)
 
 	// Tests

--- a/pkg/resource/replication_group/descriptor.go
+++ b/pkg/resource/replication_group/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("replicationgroups")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "ReplicationGroup",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/snapshot/descriptor.go
+++ b/pkg/resource/snapshot/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("snapshots")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "Snapshot",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/user/descriptor.go
+++ b/pkg/resource/user/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("users")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "User",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/user_group/descriptor.go
+++ b/pkg/resource/user_group/descriptor.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	resourceGK = metav1.GroupKind{
+	GroupVersionResource = svcapitypes.GroupVersion.WithResource("usergroups")
+	GroupKind            = metav1.GroupKind{
 		Group: "elasticache.services.k8s.aws",
 		Kind:  "UserGroup",
 	}
@@ -45,7 +46,7 @@ type resourceDescriptor struct {
 // GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
 // API Group and Kind of CRs described by the descriptor
 func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &resourceGK
+	return &GroupKind
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/templates/hooks/replication_group/sdk_file_end.go.tpl
+++ b/templates/hooks/replication_group/sdk_file_end.go.tpl
@@ -1,16 +1,15 @@
-{{ $outputShape := .CRD.GetOutputShape .CRD.Ops.Create }}
-// This method copies the data from given {{ $outputShape.ShapeName }} by populating it
+// This method copies the data from given {{ .CRD.Names.Camel }} by populating it
 // into copy of supplied resource and returns that.
-func (rm *resourceManager) set{{ $outputShape.ShapeName }}Output (
+func (rm *resourceManager) set{{ .CRD.Names.Camel }}Output (
 	r *resource,
-	obj *svcsdk.{{ $outputShape.ShapeName }},
+	obj *svcsdk.{{ .CRD.Names.Camel }},
 ) (*resource, error) {
 	if obj == nil ||
 		r == nil ||
 		r.ko == nil {
 		return nil, nil
 	}
-	resp := &svcsdk.{{ .CRD.Ops.Create.OutputRef.Shape.ShapeName }}{ {{ $outputShape.ShapeName }}:obj }
+	resp := &svcsdk.{{ .CRD.Ops.Create.OutputRef.Shape.ShapeName }}{ {{ .CRD.Names.Camel }}:obj }
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1019

Description of changes:
* Main changes in `sdk_file_end.go.tpl` , others files are auto-generated using latest `code-generator` and latest runtime
* Previously the method was named `set{{ $outputShape.ShapeName }}Output` which caused the method name to be "setCreateReplicationGroupOutputOutput" and existing `custom_update_api.go` started failing. See [#61](https://github.com/aws-controllers-k8s/elasticache-controller/pull/64)
* I do not know why elasticache team did not chose to name the method statically as `setReplicationGroupOutput` but templatized it.
* Keep the existing templatization in mind, I updated the template to produce methodName and parameter as earlier, which compiles successfully with `custom_update_api.go`
* Note: This regression occured because GetOutputShape started to correctly return Output shape as part of this [commit](https://github.com/aws-controllers-k8s/code-generator/commit/0466b013040e606a80343efe856777af74f78613)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
