### PR TITLE
Fix delta comparison for auto failover, multi AZ, primary cluster ID

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: 8e4808b17b3a814f0a624eee8d68a0b45ba5e2c4
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.52
 generator_config_info:
-  file_checksum: 28e3cd3119df8028a65eb0729a462b4354d27fa9
+  file_checksum: 23f444fb86eaa5c1acb4d4f51430e606e7ee554a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -48,6 +48,9 @@ resources:
         from:
           operation: ListAllowedNodeTypeModifications
           path: ScaleDownModifications
+      AutomaticFailoverEnabled:
+        compare:
+          is_ignored: true
       Events:
         is_read_only: true
         from:
@@ -62,6 +65,12 @@ resources:
           path: ReplicationGroup.LogDeliveryConfigurations
         compare: # removes the spec field from automatic delta comparison
           is_ignored: true
+      MultiAZEnabled:
+        compare:
+          is_ignored: true
+      PrimaryClusterId: # note: "PrimaryClusterID" will not function properly
+        compare:
+          is_ignored: true
     hooks:
       sdk_read_many_post_set_output:
         template_path: hooks/replication_group/sdk_read_many_post_set_output.go.tpl
@@ -72,7 +81,7 @@ resources:
       sdk_update_post_build_request:
         template_path: hooks/replication_group/sdk_update_post_build_request.go.tpl
       delta_post_compare:
-        code: "filterDelta(delta, a, b)"
+        code: "modifyDelta(delta, a, b)"
       sdk_file_end:
         template_path: hooks/replication_group/sdk_file_end.go.tpl
       sdk_file_end_set_output_post_populate:

--- a/generator.yaml
+++ b/generator.yaml
@@ -48,6 +48,9 @@ resources:
         from:
           operation: ListAllowedNodeTypeModifications
           path: ScaleDownModifications
+      AutomaticFailoverEnabled:
+        compare:
+          is_ignored: true
       Events:
         is_read_only: true
         from:
@@ -62,6 +65,12 @@ resources:
           path: ReplicationGroup.LogDeliveryConfigurations
         compare: # removes the spec field from automatic delta comparison
           is_ignored: true
+      MultiAZEnabled:
+        compare:
+          is_ignored: true
+      PrimaryClusterId: # note: "PrimaryClusterID" will not function properly
+        compare:
+          is_ignored: true
     hooks:
       sdk_read_many_post_set_output:
         template_path: hooks/replication_group/sdk_read_many_post_set_output.go.tpl
@@ -72,7 +81,7 @@ resources:
       sdk_update_post_build_request:
         template_path: hooks/replication_group/sdk_update_post_build_request.go.tpl
       delta_post_compare:
-        code: "filterDelta(delta, a, b)"
+        code: "modifyDelta(delta, a, b)"
       sdk_file_end:
         template_path: hooks/replication_group/sdk_file_end.go.tpl
       sdk_file_end_set_output_post_populate:

--- a/pkg/resource/replication_group/delta.go
+++ b/pkg/resource/replication_group/delta.go
@@ -55,13 +55,6 @@ func newResourceDelta(
 			delta.Add("Spec.AuthToken", a.ko.Spec.AuthToken, b.ko.Spec.AuthToken)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.AutomaticFailoverEnabled, b.ko.Spec.AutomaticFailoverEnabled) {
-		delta.Add("Spec.AutomaticFailoverEnabled", a.ko.Spec.AutomaticFailoverEnabled, b.ko.Spec.AutomaticFailoverEnabled)
-	} else if a.ko.Spec.AutomaticFailoverEnabled != nil && b.ko.Spec.AutomaticFailoverEnabled != nil {
-		if *a.ko.Spec.AutomaticFailoverEnabled != *b.ko.Spec.AutomaticFailoverEnabled {
-			delta.Add("Spec.AutomaticFailoverEnabled", a.ko.Spec.AutomaticFailoverEnabled, b.ko.Spec.AutomaticFailoverEnabled)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CacheNodeType, b.ko.Spec.CacheNodeType) {
 		delta.Add("Spec.CacheNodeType", a.ko.Spec.CacheNodeType, b.ko.Spec.CacheNodeType)
 	} else if a.ko.Spec.CacheNodeType != nil && b.ko.Spec.CacheNodeType != nil {
@@ -107,13 +100,6 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.MultiAZEnabled, b.ko.Spec.MultiAZEnabled) {
-		delta.Add("Spec.MultiAZEnabled", a.ko.Spec.MultiAZEnabled, b.ko.Spec.MultiAZEnabled)
-	} else if a.ko.Spec.MultiAZEnabled != nil && b.ko.Spec.MultiAZEnabled != nil {
-		if *a.ko.Spec.MultiAZEnabled != *b.ko.Spec.MultiAZEnabled {
-			delta.Add("Spec.MultiAZEnabled", a.ko.Spec.MultiAZEnabled, b.ko.Spec.MultiAZEnabled)
-		}
-	}
 	if !reflect.DeepEqual(a.ko.Spec.NodeGroupConfiguration, b.ko.Spec.NodeGroupConfiguration) {
 		delta.Add("Spec.NodeGroupConfiguration", a.ko.Spec.NodeGroupConfiguration, b.ko.Spec.NodeGroupConfiguration)
 	}
@@ -146,13 +132,6 @@ func newResourceDelta(
 	} else if a.ko.Spec.PreferredMaintenanceWindow != nil && b.ko.Spec.PreferredMaintenanceWindow != nil {
 		if *a.ko.Spec.PreferredMaintenanceWindow != *b.ko.Spec.PreferredMaintenanceWindow {
 			delta.Add("Spec.PreferredMaintenanceWindow", a.ko.Spec.PreferredMaintenanceWindow, b.ko.Spec.PreferredMaintenanceWindow)
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.PrimaryClusterID, b.ko.Spec.PrimaryClusterID) {
-		delta.Add("Spec.PrimaryClusterID", a.ko.Spec.PrimaryClusterID, b.ko.Spec.PrimaryClusterID)
-	} else if a.ko.Spec.PrimaryClusterID != nil && b.ko.Spec.PrimaryClusterID != nil {
-		if *a.ko.Spec.PrimaryClusterID != *b.ko.Spec.PrimaryClusterID {
-			delta.Add("Spec.PrimaryClusterID", a.ko.Spec.PrimaryClusterID, b.ko.Spec.PrimaryClusterID)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ReplicasPerNodeGroup, b.ko.Spec.ReplicasPerNodeGroup) {
@@ -217,6 +196,6 @@ func newResourceDelta(
 		delta.Add("Spec.UserGroupIDs", a.ko.Spec.UserGroupIDs, b.ko.Spec.UserGroupIDs)
 	}
 
-	filterDelta(delta, a, b)
+	modifyDelta(delta, a, b)
 	return delta
 }

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -555,7 +555,6 @@ class TestReplicationGroup:
         assert_misc_fields(reference, rg_update_misc_input['RG_ID'], pmw, description, srl, sw)
 
     # test modifying properties related to tolerance: replica promotion, multi AZ, automatic failover
-    @pytest.mark.blocked  # TODO: remove when passing
     def test_rg_fault_tolerance(self, rg_fault_tolerance):
         (reference, _) = rg_fault_tolerance
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=30)
@@ -607,8 +606,8 @@ class TestReplicationGroup:
                 raise AssertionError(f"Unknown node {node['cacheClusterID']}")
 
         # assert AF and multi AZ
-        assert resource['status']['automaticFailover'] == "disabled"
-        assert resource['status']['multiAZ'] == "disabled"
+        assert resource['status']['automaticFailover'] == "enabled"
+        assert resource['status']['multiAZ'] == "enabled"
 
     # test association and disassociation of other resources (VPC security groups, SNS topic, user groups)
     @pytest.mark.blocked  # TODO: remove when passing


### PR DESCRIPTION
Nice.

Description of changes:
Properly retrieve the latest state for these 3 fields and compare them to the desired state. For each of these 3 spec fields, obtaining the corresponding latest state requires processing of a different `Status` field due to the structure of the `DescribeReplicationGroups` API response

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
