### PR TITLE
adding in missing kinds to olm config

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -46,6 +46,10 @@ samples:
   spec: '{}'
 - kind: Snapshot
   spec: '{}'
+- kind: UserGroup
+  spec: '{}'
+- kind: User
+  spec: '{}'
 maintainers:
 - name: "elasticache maintainer team"
   email: "ack-maintainers@amazon.com"


### PR DESCRIPTION
Signed-off-by: Adam D. Cornett <adc@redhat.com>

Issue #, if available:
N/A
Description of changes:
Adding in the missing `kinds` to the olm config file. This ensures that when the `bundle` is created via the release process that `operator-sdk` does not throw any `warnings`. This then allows the PR to the community repos to be raised without any issues since the community repos run `operator-sdk validate bundle` which may reject `warnings`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
