### PR TITLE
Rename `ReplicationGroupDescription` to `Description`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-03-25T18:32:50Z"
-  build_hash: c6b852a8017aa73cfc5a882b1ba60c88d820e967
-  go_version: go1.17.5
-  version: v0.18.1
-api_directory_checksum: 246af92291668493e03954b4e4117c21f5b62790
+  build_date: "2022-04-11T23:03:51Z"
+  build_hash: fc5620cf5fde243ee5124324d26bb7e952049bf2
+  go_version: go1.17.8
+  version: v0.18.3
+api_directory_checksum: 7087207d90a71ce286e3c45edad16bb89b0a8eb3
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 4fd6f317804ecb5192bfb88c569ae335d418248b
+  file_checksum: 2461349a2827ec98ae7440fbff3301c1effcfaf4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -82,6 +82,14 @@ resources:
         template_path: hooks/replication_group/sdk_file_end.go.tpl
       sdk_file_end_set_output_post_populate:
         code: "rm.customSetOutput(obj, ko) // custom set output from obj"
+    renames:
+      operations:
+        CreateReplicationGroup:
+          input_fields:
+            ReplicationGroupDescription: Description
+        ModifyReplicationGroup:
+          input_fields:
+            ReplicationGroupDescription: Description
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:

--- a/apis/v1alpha1/replication_group.go
+++ b/apis/v1alpha1/replication_group.go
@@ -131,6 +131,9 @@ type ReplicationGroupSpec struct {
 	// a subnet group before you start creating a cluster. For more information,
 	// see Subnets and Subnet Groups (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html).
 	CacheSubnetGroupName *string `json:"cacheSubnetGroupName,omitempty"`
+	// A user-created description for the replication group.
+	// +kubebuilder:validation:Required
+	Description *string `json:"description"`
 	// The name of the cache engine to be used for the clusters in this replication
 	// group. Must be Redis.
 	Engine *string `json:"engine,omitempty"`
@@ -228,9 +231,6 @@ type ReplicationGroupSpec struct {
 	// An optional parameter that specifies the number of replica nodes in each
 	// node group (shard). Valid values are 0 to 5.
 	ReplicasPerNodeGroup *int64 `json:"replicasPerNodeGroup,omitempty"`
-	// A user-created description for the replication group.
-	// +kubebuilder:validation:Required
-	ReplicationGroupDescription *string `json:"replicationGroupDescription"`
 	// The replication group identifier. This parameter is stored as a lowercase
 	// string.
 	//
@@ -354,9 +354,6 @@ type ReplicationGroupStatus struct {
 	// endpoint to connect to this replication group.
 	// +kubebuilder:validation:Optional
 	ConfigurationEndpoint *Endpoint `json:"configurationEndpoint,omitempty"`
-	// The user supplied description of the replication group.
-	// +kubebuilder:validation:Optional
-	Description *string `json:"description,omitempty"`
 	// A list of events. Each element in the list contains detailed information
 	// about one event.
 	// +kubebuilder:validation:Optional

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2139,6 +2139,11 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Description != nil {
+		in, out := &in.Description, &out.Description
+		*out = new(string)
+		**out = **in
+	}
 	if in.Engine != nil {
 		in, out := &in.Engine, &out.Engine
 		*out = new(string)
@@ -2220,11 +2225,6 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 	if in.ReplicasPerNodeGroup != nil {
 		in, out := &in.ReplicasPerNodeGroup, &out.ReplicasPerNodeGroup
 		*out = new(int64)
-		**out = **in
-	}
-	if in.ReplicationGroupDescription != nil {
-		in, out := &in.ReplicationGroupDescription, &out.ReplicationGroupDescription
-		*out = new(string)
 		**out = **in
 	}
 	if in.ReplicationGroupID != nil {
@@ -2372,11 +2372,6 @@ func (in *ReplicationGroupStatus) DeepCopyInto(out *ReplicationGroupStatus) {
 		in, out := &in.ConfigurationEndpoint, &out.ConfigurationEndpoint
 		*out = new(Endpoint)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.Description != nil {
-		in, out := &in.Description, &out.Description
-		*out = new(string)
-		**out = **in
 	}
 	if in.Events != nil {
 		in, out := &in.Events, &out.Events

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -144,6 +144,9 @@ spec:
                   creating a cluster. For more information, see Subnets and Subnet
                   Groups (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html)."
                 type: string
+              description:
+                description: A user-created description for the replication group.
+                type: string
               engine:
                 description: The name of the cache engine to be used for the clusters
                   in this replication group. Must be Redis.
@@ -293,9 +296,6 @@ spec:
                   nodes in each node group (shard). Valid values are 0 to 5.
                 format: int64
                 type: integer
-              replicationGroupDescription:
-                description: A user-created description for the replication group.
-                type: string
               replicationGroupID:
                 description: "The replication group identifier. This parameter is
                   stored as a lowercase string. \n Constraints: \n    * A name must
@@ -383,7 +383,7 @@ spec:
                   type: string
                 type: array
             required:
-            - replicationGroupDescription
+            - description
             - replicationGroupID
             type: object
           status:
@@ -496,9 +496,6 @@ spec:
                     format: int64
                     type: integer
                 type: object
-              description:
-                description: The user supplied description of the replication group.
-                type: string
               events:
                 description: A list of events. Each element in the list contains detailed
                   information about one event.

--- a/generator.yaml
+++ b/generator.yaml
@@ -82,6 +82,14 @@ resources:
         template_path: hooks/replication_group/sdk_file_end.go.tpl
       sdk_file_end_set_output_post_populate:
         code: "rm.customSetOutput(obj, ko) // custom set output from obj"
+    renames:
+      operations:
+        CreateReplicationGroup:
+          input_fields:
+            ReplicationGroupDescription: Description
+        ModifyReplicationGroup:
+          input_fields:
+            ReplicationGroupDescription: Description
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:

--- a/go.local.mod
+++ b/go.local.mod
@@ -34,6 +34,8 @@ require (
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/itchyny/gojq v0.12.6 // indirect
+	github.com/itchyny/timefmt-go v0.1.3 // indirect
 	github.com/jaypipes/envutil v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -50,7 +52,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
+	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -144,6 +144,9 @@ spec:
                   creating a cluster. For more information, see Subnets and Subnet
                   Groups (https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/SubnetGroups.html)."
                 type: string
+              description:
+                description: A user-created description for the replication group.
+                type: string
               engine:
                 description: The name of the cache engine to be used for the clusters
                   in this replication group. Must be Redis.
@@ -293,9 +296,6 @@ spec:
                   nodes in each node group (shard). Valid values are 0 to 5.
                 format: int64
                 type: integer
-              replicationGroupDescription:
-                description: A user-created description for the replication group.
-                type: string
               replicationGroupID:
                 description: "The replication group identifier. This parameter is
                   stored as a lowercase string. \n Constraints: \n    * A name must
@@ -383,7 +383,7 @@ spec:
                   type: string
                 type: array
             required:
-            - replicationGroupDescription
+            - description
             - replicationGroupID
             type: object
           status:
@@ -496,9 +496,6 @@ spec:
                     format: int64
                     type: integer
                 type: object
-              description:
-                description: The user supplied description of the replication group.
-                type: string
               events:
                 description: A list of events. Each element in the list contains detailed
                   information about one event.

--- a/pkg/resource/cache_parameter_group/sdk.go
+++ b/pkg/resource/cache_parameter_group/sdk.go
@@ -17,6 +17,7 @@ package cache_parameter_group
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -333,8 +334,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -342,7 +343,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -17,6 +17,7 @@ package cache_subnet_group
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -475,8 +476,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -484,7 +485,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)

--- a/pkg/resource/replication_group/custom_update_api_test.go
+++ b/pkg/resource/replication_group/custom_update_api_test.go
@@ -16,6 +16,10 @@ package replication_group
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+
 	"github.com/aws-controllers-k8s/elasticache-controller/pkg/testutil"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
@@ -23,10 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"strconv"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -267,7 +268,7 @@ func validatePayloadReplicaConfig(
 func TestDecreaseReplicaCountMock(t *testing.T) {
 	assert := assert.New(t)
 	// Setup mock API response
-	var mockReplicationGroupDescription = "mock_replication_group_description"
+	var mockDescription = "mock_replication_group_description"
 	var mockOutput svcsdk.DecreaseReplicaCountOutput
 	testutil.LoadFromFixture(filepath.Join("testdata", "DecreaseReplicaCountOutput.json"), &mockOutput)
 	mocksdkapi := &mocksvcsdkapi.ElastiCacheAPI{}
@@ -278,7 +279,7 @@ func TestDecreaseReplicaCountMock(t *testing.T) {
 		desired := provideResource()
 		latest := provideResource()
 		res, _ := rm.decreaseReplicaCount(context.Background(), desired, latest)
-		assert.Equal(mockReplicationGroupDescription, *res.ko.Status.Description)
+		assert.Equal(mockDescription, *res.ko.Spec.Description)
 	})
 }
 

--- a/pkg/resource/replication_group/delta.go
+++ b/pkg/resource/replication_group/delta.go
@@ -79,6 +79,13 @@ func newResourceDelta(
 			delta.Add("Spec.CacheSubnetGroupName", a.ko.Spec.CacheSubnetGroupName, b.ko.Spec.CacheSubnetGroupName)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
+		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
+	} else if a.ko.Spec.Description != nil && b.ko.Spec.Description != nil {
+		if *a.ko.Spec.Description != *b.ko.Spec.Description {
+			delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Engine, b.ko.Spec.Engine) {
 		delta.Add("Spec.Engine", a.ko.Spec.Engine, b.ko.Spec.Engine)
 	} else if a.ko.Spec.Engine != nil && b.ko.Spec.Engine != nil {
@@ -139,13 +146,6 @@ func newResourceDelta(
 	} else if a.ko.Spec.ReplicasPerNodeGroup != nil && b.ko.Spec.ReplicasPerNodeGroup != nil {
 		if *a.ko.Spec.ReplicasPerNodeGroup != *b.ko.Spec.ReplicasPerNodeGroup {
 			delta.Add("Spec.ReplicasPerNodeGroup", a.ko.Spec.ReplicasPerNodeGroup, b.ko.Spec.ReplicasPerNodeGroup)
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.ReplicationGroupDescription, b.ko.Spec.ReplicationGroupDescription) {
-		delta.Add("Spec.ReplicationGroupDescription", a.ko.Spec.ReplicationGroupDescription, b.ko.Spec.ReplicationGroupDescription)
-	} else if a.ko.Spec.ReplicationGroupDescription != nil && b.ko.Spec.ReplicationGroupDescription != nil {
-		if *a.ko.Spec.ReplicationGroupDescription != *b.ko.Spec.ReplicationGroupDescription {
-			delta.Add("Spec.ReplicationGroupDescription", a.ko.Spec.ReplicationGroupDescription, b.ko.Spec.ReplicationGroupDescription)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ReplicationGroupID, b.ko.Spec.ReplicationGroupID) {

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -17,6 +17,7 @@ package replication_group
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -131,9 +132,9 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.ConfigurationEndpoint = nil
 		}
 		if elem.Description != nil {
-			ko.Status.Description = elem.Description
+			ko.Spec.Description = elem.Description
 		} else {
-			ko.Status.Description = nil
+			ko.Spec.Description = nil
 		}
 		if elem.GlobalReplicationGroupInfo != nil {
 			f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -568,9 +569,9 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ConfigurationEndpoint = nil
 	}
 	if resp.ReplicationGroup.Description != nil {
-		ko.Status.Description = resp.ReplicationGroup.Description
+		ko.Spec.Description = resp.ReplicationGroup.Description
 	} else {
-		ko.Status.Description = nil
+		ko.Spec.Description = nil
 	}
 	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
 		f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -1023,8 +1024,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.ReplicasPerNodeGroup != nil {
 		res.SetReplicasPerNodeGroup(*r.ko.Spec.ReplicasPerNodeGroup)
 	}
-	if r.ko.Spec.ReplicationGroupDescription != nil {
-		res.SetReplicationGroupDescription(*r.ko.Spec.ReplicationGroupDescription)
+	if r.ko.Spec.Description != nil {
+		res.SetReplicationGroupDescription(*r.ko.Spec.Description)
 	}
 	if r.ko.Spec.ReplicationGroupID != nil {
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
@@ -1220,9 +1221,9 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.ConfigurationEndpoint = nil
 	}
 	if resp.ReplicationGroup.Description != nil {
-		ko.Status.Description = resp.ReplicationGroup.Description
+		ko.Spec.Description = resp.ReplicationGroup.Description
 	} else {
-		ko.Status.Description = nil
+		ko.Spec.Description = nil
 	}
 	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
 		f9 := &svcapitypes.GlobalReplicationGroupInfo{}
@@ -1602,8 +1603,8 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.PrimaryClusterID != nil {
 		res.SetPrimaryClusterId(*r.ko.Spec.PrimaryClusterID)
 	}
-	if r.ko.Spec.ReplicationGroupDescription != nil {
-		res.SetReplicationGroupDescription(*r.ko.Spec.ReplicationGroupDescription)
+	if r.ko.Spec.Description != nil {
+		res.SetReplicationGroupDescription(*r.ko.Spec.Description)
 	}
 	if r.ko.Spec.ReplicationGroupID != nil {
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
@@ -1749,8 +1750,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -1758,7 +1759,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)
@@ -1897,9 +1898,9 @@ func (rm *resourceManager) setReplicationGroupOutput(
 		ko.Status.ConfigurationEndpoint = nil
 	}
 	if resp.ReplicationGroup.Description != nil {
-		ko.Status.Description = resp.ReplicationGroup.Description
+		ko.Spec.Description = resp.ReplicationGroup.Description
 	} else {
-		ko.Status.Description = nil
+		ko.Spec.Description = nil
 	}
 	if resp.ReplicationGroup.GlobalReplicationGroupInfo != nil {
 		f9 := &svcapitypes.GlobalReplicationGroupInfo{}

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_create.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_create.yaml
@@ -6,5 +6,5 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade.yaml
@@ -7,7 +7,7 @@ spec:
   engineVersion: 5.0.6 # new config has been applied; this is the new engine version but no action has been taken yet
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_engine_version_upgrade_latest.yaml
@@ -7,7 +7,7 @@ spec:
   engineVersion: 5.0.0 # this should still be the old engine version
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 2 # mismatch between this and member clusters because new config was just applied
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_increase_replica_latest.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1 # as this is the latest state, replicasPerNodeGroup should be consistent with memberClusters/nodeGroups
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_desired.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_desired.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_before_scale_up_latest.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed.yaml
@@ -8,7 +8,7 @@ spec:
   numNodeGroups: 1
   preferredMaintenanceWindow: "wed:08:00-wed:09:00"
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   snapshotRetentionLimit: 0
   snapshotWindow: "10:00-11:00"

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed_latest.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_completed_latest.yaml
@@ -9,7 +9,7 @@ spec:
   numNodeGroups: 1
   preferredMaintenanceWindow: "wed:08:00-wed:09:00"
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   snapshotRetentionLimit: 0
   snapshotWindow: "10:00-11:00"

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_create_initiated.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   SnapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_delete_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_delete_initiated.yaml
@@ -7,7 +7,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   snapshotRetentionLimit: 0
   snapshotWindow: "10:00-11:00"

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_engine_upgrade_initiated.yaml
@@ -7,7 +7,7 @@ spec:
   engineVersion: 5.0.6 # resource has 5.0.0 but custom modify code copies desired EV to latest and doesn't overwrite it
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_increase_replica_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_increase_replica_initiated.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 2 # new replica hasn't been added, but 2 comes from desired and isn't overwritten in custom modify code
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   snapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_invalid_before_create.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_invalid_before_create.yaml
@@ -6,5 +6,5 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 7
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_invalid_create_attempted.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_invalid_create_attempted.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 7
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
 status:
   ackResourceMetadata:

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cmd_scale_up_initiated.yaml
@@ -6,7 +6,7 @@ spec:
   engine: redis
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: rg-cmd
   atRestEncryptionEnabled: false
   SnapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_before_create.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_before_create.yaml
@@ -20,5 +20,5 @@ spec:
       replicaCount: 3
       slots: 6000-16383
   numNodeGroups: 2
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: rg-cme

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_create_initiated.yaml
@@ -20,7 +20,7 @@ spec:
       replicaCount: 3
       slots: 6000-16383
   numNodeGroups: 2
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: rg-cme
   atRestEncryptionEnabled: false
   SnapshotRetentionLimit: 0

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_invalid_scale_out_attempted.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_invalid_scale_out_attempted.yaml
@@ -21,7 +21,7 @@ spec:
       replicaCount: 3
       slots: 6000-16383
   numNodeGroups: 3 # this is the mismatch; 3 shards indicated but only 2 are specified in above nodeGroupConfiguration
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: rg-cme
 status:
   ackResourceMetadata:

--- a/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_shard_mismatch.yaml
+++ b/pkg/resource/replication_group/testdata/replication_group/cr/rg_cme_shard_mismatch.yaml
@@ -21,7 +21,7 @@ spec:
       replicaCount: 3
       slots: 6000-16383
   numNodeGroups: 3 # this is the mismatch; 3 shards indicated but only 2 are specified in above nodeGroupConfiguration
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: rg-cme
 status:
   ackResourceMetadata:

--- a/pkg/resource/snapshot/custom_create_api.go
+++ b/pkg/resource/snapshot/custom_create_api.go
@@ -15,6 +15,7 @@ package snapshot
 
 import (
 	"context"
+
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws/awserr"

--- a/pkg/resource/snapshot/sdk.go
+++ b/pkg/resource/snapshot/sdk.go
@@ -17,6 +17,7 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -680,8 +681,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -689,7 +690,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -17,6 +17,7 @@ package user
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -511,8 +512,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -520,7 +521,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)

--- a/pkg/resource/user_group/sdk.go
+++ b/pkg/resource/user_group/sdk.go
@@ -17,6 +17,7 @@ package user_group
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -421,8 +422,8 @@ func (rm *resourceManager) updateConditions(
 			syncCondition = condition
 		}
 	}
-
-	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+	var termError *ackerr.TerminalError
+	if rm.terminalAWSError(err) || err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 		if terminalCondition == nil {
 			terminalCondition = &ackv1alpha1.Condition{
 				Type: ackv1alpha1.ConditionTypeTerminal,
@@ -430,7 +431,7 @@ func (rm *resourceManager) updateConditions(
 			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
 		}
 		var errorMessage = ""
-		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound {
+		if err == ackerr.SecretTypeNotSupported || err == ackerr.SecretNotFound || errors.As(err, &termError) {
 			errorMessage = err.Error()
 		} else {
 			awsErr, _ := ackerr.AWSError(err)

--- a/test/e2e/resources/replicationgroup_authtoken.yaml
+++ b/test/e2e/resources/replicationgroup_authtoken.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
     engine: redis
     replicationGroupID: $RG_ID
-    replicationGroupDescription: Auth token test
+    description: Auth token test
     cacheNodeType: cache.t3.micro
     numNodeGroups: 1
     replicasPerNodeGroup: 0

--- a/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_fromsnapshot.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   cacheNodeType: cache.t3.micro
   engine: redis
-  replicationGroupDescription: test replication group for input field coverage
+  description: test replication group for input field coverage
   replicationGroupID: $RG_ID
   snapshotName: $SNAPSHOT_NAME
   numNodeGroups: 1

--- a/test/e2e/resources/replicationgroup_cmd_update.yaml
+++ b/test/e2e/resources/replicationgroup_cmd_update.yaml
@@ -9,5 +9,5 @@ spec:
   engineVersion: $ENGINE_VERSION
   numNodeGroups: $NUM_NODE_GROUPS
   replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: $RG_ID

--- a/test/e2e/resources/replicationgroup_cme_misc.yaml
+++ b/test/e2e/resources/replicationgroup_cme_misc.yaml
@@ -10,7 +10,7 @@ spec:
   numNodeGroups: 2
   preferredMaintenanceWindow: $PMW
   replicasPerNodeGroup: 1
-  replicationGroupDescription: $DESCRIPTION
+  description: $DESCRIPTION
   replicationGroupID: $RG_ID
   snapshotRetentionLimit: $SRL
   snapshotWindow: $SW

--- a/test/e2e/resources/replicationgroup_cme_ngc.yaml
+++ b/test/e2e/resources/replicationgroup_cme_ngc.yaml
@@ -20,5 +20,5 @@ spec:
         - us-west-2c
         - us-west-2a
       replicaCount: 2
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: $RG_ID

--- a/test/e2e/resources/replicationgroup_fault_tolerance.yaml
+++ b/test/e2e/resources/replicationgroup_fault_tolerance.yaml
@@ -10,5 +10,5 @@ spec:
   multiAZEnabled: $MAZ_ENABLED
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: description
+  description: description
   replicationGroupID: $RG_ID

--- a/test/e2e/resources/replicationgroup_input_coverage.yaml
+++ b/test/e2e/resources/replicationgroup_input_coverage.yaml
@@ -32,7 +32,7 @@ spec:
   numNodeGroups: 2
   port: 6380
   preferredMaintenanceWindow: sun:23:00-mon:01:30
-  replicationGroupDescription: test replication group for input field coverage
+  description: test replication group for input field coverage
   replicationGroupID: $RG_ID
   securityGroupIDs:
     - $SG_ID

--- a/test/e2e/resources/replicationgroup_largecluster.yaml
+++ b/test/e2e/resources/replicationgroup_largecluster.yaml
@@ -7,5 +7,5 @@ spec:
   engine: redis
   numNodeGroups: $NUM_NODE_GROUPS
   replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
-  replicationGroupDescription: large cluster mode enabled RG
+  description: large cluster mode enabled RG
   replicationGroupID: $RG_ID

--- a/test/e2e/resources/replicationgroup_primary_cluster.yaml
+++ b/test/e2e/resources/replicationgroup_primary_cluster.yaml
@@ -7,6 +7,6 @@ spec:
   # cache node type and engine cannot be used when specifying existing primary node, even if DNE
   numNodeGroups: 1
   replicasPerNodeGroup: 1
-  replicationGroupDescription: cluster-mode disabled RG
+  description: cluster-mode disabled RG
   replicationGroupID: $RG_ID
   primaryClusterID: $PRIMARY_NODE

--- a/test/e2e/resources/replicationgroup_rpng.yaml
+++ b/test/e2e/resources/replicationgroup_rpng.yaml
@@ -11,5 +11,5 @@ spec:
   engine: redis
   numNodeGroups: $NUM_NODE_GROUPS
   replicasPerNodeGroup: $REPLICAS_PER_NODE_GROUP
-  replicationGroupDescription: cluster-mode enabled RG
+  description: cluster-mode enabled RG
   replicationGroupID: $RG_ID

--- a/test/e2e/scenarios/Resharding/cme_scale_in_config_rollback.yaml
+++ b/test/e2e/scenarios/Resharding/cme_scale_in_config_rollback.yaml
@@ -15,7 +15,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: reshard$RANDOM_SUFFIX
-        replicationGroupDescription: Scaling in rollback
+        description: Scaling in rollback
         cacheNodeType: cache.m5.large
         snapshotName: test-scale-in-config-rollback
         cacheParameterGroupName: default.redis6.x.cluster.on

--- a/test/e2e/scenarios/Resharding/cme_scale_in_rollback.yaml
+++ b/test/e2e/scenarios/Resharding/cme_scale_in_rollback.yaml
@@ -15,7 +15,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: reshard$RANDOM_SUFFIX
-        replicationGroupDescription: Scaling in rollback
+        description: Scaling in rollback
         cacheNodeType: cache.m5.large
         numNodeGroups: 2
         snapshotName: test-scale-in-rollback

--- a/test/e2e/scenarios/ScaleUpAndDown/cmd_basic_create_update.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cmd_basic_create_update.yaml
@@ -15,7 +15,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Basic create and update of CMD RG
+        description: Basic create and update of CMD RG
         cacheNodeType: cache.t3.micro
         numNodeGroups: 1
     wait:

--- a/test/e2e/scenarios/ScaleUpAndDown/cmd_scale_down.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cmd_scale_down.yaml
@@ -12,7 +12,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Scale down for CMD
+        description: Scale down for CMD
         cacheNodeType: cache.t3.medium
         numNodeGroups: 1
     wait:

--- a/test/e2e/scenarios/ScaleUpAndDown/cmd_scale_up.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cmd_scale_up.yaml
@@ -12,7 +12,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Scale up for CMD
+        description: Scale up for CMD
         cacheNodeType: cache.t3.micro
         numNodeGroups: 1
     wait:

--- a/test/e2e/scenarios/ScaleUpAndDown/cme_scale_down.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cme_scale_down.yaml
@@ -12,7 +12,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Scale down CME
+        description: Scale down CME
         cacheNodeType: cache.t3.medium
         numNodeGroups: 2
     wait:

--- a/test/e2e/scenarios/ScaleUpAndDown/cme_scale_down_rollback.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cme_scale_down_rollback.yaml
@@ -15,7 +15,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Scalind down rollback
+        description: Scaling down rollback
         cacheNodeType: cache.m5.large
         numNodeGroups: 2
         snapshotName: test-scale-down-rollback

--- a/test/e2e/scenarios/ScaleUpAndDown/cme_scale_up.yaml
+++ b/test/e2e/scenarios/ScaleUpAndDown/cme_scale_up.yaml
@@ -12,7 +12,7 @@ steps:
       spec:
         engine: redis
         replicationGroupID: scaling$RANDOM_SUFFIX
-        replicationGroupDescription: Scale Up CME
+        description: Scale Up CME
         cacheNodeType: cache.t3.micro
         numNodeGroups: 2
     wait:

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -232,7 +232,7 @@ def assert_misc_fields(reference, rg_id, pmw, description, srl, sw):
     rg = retrieve_replication_group(rg_id)
     assert cc is not None
     assert cc['PreferredMaintenanceWindow'] == pmw
-    assert resource['status']['description'] == description
+    assert resource['spec']['description'] == description
     assert rg['SnapshotRetentionLimit'] == srl
     assert rg['SnapshotWindow'] == sw
 

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -542,7 +542,7 @@ class TestReplicationGroup:
         sw = "15:00-17:00"
         patch = {"spec": {
                 "preferredMaintenanceWindow": pmw,
-                "replicationGroupDescription": description,
+                "description": description,
                 "snapshotRetentionLimit": srl,
                 "snapshotWindow": sw
             }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1250

Description of changes:
Renamed the `CreateReplicationGroup` and `ModifyReplicationGroup` input field `ReplicationGroupDescription` to simply be `Description`, to match the `DescribeReplicationGroups` output shape

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
