### PR TITLE
Release artifacts for release `v0.0.18`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-04-11T23:03:51Z"
-  build_hash: fc5620cf5fde243ee5124324d26bb7e952049bf2
+  build_date: "2022-04-12T21:36:10Z"
+  build_hash: 9191f9d8912cf9c413cc45285cd0ea8bedd944f5
   go_version: go1.17.8
-  version: v0.18.3
+  version: v0.18.3-1-g9191f9d-dirty
 api_directory_checksum: 7087207d90a71ce286e3c45edad16bb89b0a8eb3
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	ackrtutil "github.com/aws-controllers-k8s/runtime/pkg/util"
@@ -31,7 +32,6 @@ import (
 
 	svctypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
 	svcresource "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource"
-	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/cache_parameter_group"
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/cache_subnet_group"
@@ -39,6 +39,8 @@ import (
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/snapshot"
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/user"
 	_ "github.com/aws-controllers-k8s/elasticache-controller/pkg/resource/user_group"
+
+	"github.com/aws-controllers-k8s/elasticache-controller/pkg/version"
 )
 
 var (
@@ -104,7 +106,11 @@ func main() {
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup, awsServiceEndpointsID,
-		ackrt.VersionInfo{}, // TODO: populate version info
+		ackrt.VersionInfo{
+			version.GitCommit,
+			version.GitVersion,
+			version.BuildDate,
+		},
 	).WithLogger(
 		ctrlrt.Log,
 	).WithResourceManagerFactories(

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/elasticache-controller
-  newTag: v0.0.17
+  newTag: v0.0.18

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: elasticache-chart
 description: A Helm chart for the ACK service controller for Amazon ElastiCache (ElastiCache)
-version: v0.0.17
-appVersion: v0.0.17
+version: v0.0.18
+appVersion: v0.0.18
 home: https://github.com/aws-controllers-k8s/elasticache-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/elasticache-controller:v0.0.17".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/elasticache-controller:v0.0.18".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/elasticache-controller
-  tag: v0.0.17
+  tag: v0.0.18
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:
Regenerated controller with latest runtime for release `v0.0.18`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
