### PR TITLE
Add subnetIDs after custom describe to fix `spec.subnetIDs: Required value`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-03-09T15:59:05Z"
+  build_date: "2023-03-10T17:52:20Z"
   build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
   go_version: go1.19
   version: v0.24.3

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-03-07T21:35:18Z"
+  build_date: "2023-03-09T15:59:05Z"
   build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
   go_version: go1.19
   version: v0.24.3
@@ -7,7 +7,7 @@ api_directory_checksum: 885f952f7ca2ce7a676b9bbf8eb262de71de6238
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 2461349a2827ec98ae7440fbff3301c1effcfaf4
+  file_checksum: 8b1f9e0bb52e26722d71cbd1ee3d489a0e3970c6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -18,6 +18,9 @@ resources:
         from:
           operation: DescribeEvents
           path: Events
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
   ReplicationGroup:
     exceptions:
       terminal_codes:

--- a/generator.yaml
+++ b/generator.yaml
@@ -18,6 +18,9 @@ resources:
         from:
           operation: DescribeEvents
           path: Events
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
   ReplicationGroup:
     exceptions:
       terminal_codes:

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -150,6 +150,15 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+
+	if ko.Status.Subnets != nil {
+		for _, subnetIdIter := range ko.Status.Subnets {
+			if subnetIdIter.SubnetIdentifier != nil {
+				ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+			}
+		}
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/cache_subnet_group/sdk.go
+++ b/pkg/resource/cache_subnet_group/sdk.go
@@ -151,11 +151,9 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 
-	if ko.Status.Subnets != nil {
-		for _, subnetIdIter := range ko.Status.Subnets {
-			if subnetIdIter.SubnetIdentifier != nil {
-				ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
-			}
+	for _, subnetIdIter := range ko.Status.Subnets {
+		if subnetIdIter.SubnetIdentifier != nil {
+			ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
 		}
 	}
 

--- a/templates/hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -1,8 +1,6 @@
 
-        if ko.Status.Subnets != nil {
-                for _, subnetIdIter := range ko.Status.Subnets {
-                        if subnetIdIter.SubnetIdentifier != nil {
-                                ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
-                        }
+        for _, subnetIdIter := range ko.Status.Subnets {
+                if subnetIdIter.SubnetIdentifier != nil {
+                        ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
                 }
         }

--- a/templates/hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/cache_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,8 @@
+
+        if ko.Status.Subnets != nil {
+                for _, subnetIdIter := range ko.Status.Subnets {
+                        if subnetIdIter.SubnetIdentifier != nil {
+                                ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+                        }
+                }
+        }


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-controllers-k8s/community/issues/1725

**Description of changes:**
- Adding the subnetIDs after the custom describe operation in order to populate the `spec.subnetIDs` field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
