### PR TITLE
redis >=6 skip patch version compare

### DIFF
--- a/pkg/resource/replication_group/delta_util.go
+++ b/pkg/resource/replication_group/delta_util.go
@@ -83,21 +83,14 @@ func engineVersionsMatch(
 		return true
 	}
 
-	// if the last character of desiredEV is "x", only check for a major version match
+	dMaj, dMin, _ := versionNumbersFromString(desiredEV)
+	lMaj, lMin, _ := versionNumbersFromString(latestEV)
 	last := len(desiredEV) - 1
-	if desiredEV[last:] == "x" {
-		// cut off the "x" and replace all occurrences of '.' with '\.' (as '.' is a special regex character)
-		desired := strings.Replace(desiredEV[:last], ".", "\\.", -1)
-		r, _ := regexp.Compile(desired + ".*")
-		return r.MatchString(latestEV)
-	}
 
-	// if the version is higher than 6, skip the upstream patch version when comparing.
+	// if the last character of desiredEV is "x" or the major version is higher than 5, ignore patch version when comparing.
 	// See https://github.com/aws-controllers-k8s/community/issues/1737
-	majorVersion, _ := strconv.Atoi(desiredEV[0:1])
-	if majorVersion >= 6 {
-		r, _ := regexp.Compile(desiredEV + ".*")
-		return r.MatchString(latestEV)
+	if dMaj > 5 || desiredEV[last:] == "x" {
+		return dMaj == lMaj && (dMin < 0 || dMin == lMin)
 	}
 
 	return false
@@ -195,4 +188,29 @@ func primaryClusterIDRequiresUpdate(desired *resource, latest *resource) (bool, 
 	}
 
 	return false, nil
+}
+
+// versionNumbersFromString takes a version string like "6.2", "6.x" or "7.0.4" and
+// returns the major, minor and patch numbers. If no minor or patch numbers are present
+// or contain the "x" placeholder, -1 is returned for that version number.
+func versionNumbersFromString(version string) (int, int, int) {
+	parts := strings.Split(version, ".")
+	major := -1
+	minor := -1
+	patch := -1
+	if len(parts) == 0 {
+		return major, minor, patch
+	}
+	major, _ = strconv.Atoi(parts[0])
+	if len(parts) > 1 {
+		if !strings.EqualFold(parts[1], "x") {
+			minor, _ = strconv.Atoi(parts[1])
+		}
+	}
+	if len(parts) > 2 {
+		if !strings.EqualFold(parts[2], "x") {
+			patch, _ = strconv.Atoi(parts[2])
+		}
+	}
+	return major, minor, patch
 }

--- a/pkg/resource/replication_group/delta_util.go
+++ b/pkg/resource/replication_group/delta_util.go
@@ -16,7 +16,6 @@ package replication_group
 import (
 	"encoding/json"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 

--- a/pkg/resource/replication_group/delta_util.go
+++ b/pkg/resource/replication_group/delta_util.go
@@ -17,8 +17,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 
@@ -93,6 +93,7 @@ func engineVersionsMatch(
 	}
 
 	// if the version is higher than 6, skip the upstream patch version when comparing.
+	// See https://github.com/aws-controllers-k8s/community/issues/1737
 	majorVersion, _ := strconv.Atoi(desiredEV[0:1])
 	if majorVersion >= 6 {
 		r, _ := regexp.Compile(desiredEV + ".*")

--- a/pkg/resource/replication_group/delta_util.go
+++ b/pkg/resource/replication_group/delta_util.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"strconv"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 
@@ -88,6 +89,13 @@ func engineVersionsMatch(
 		// cut off the "x" and replace all occurrences of '.' with '\.' (as '.' is a special regex character)
 		desired := strings.Replace(desiredEV[:last], ".", "\\.", -1)
 		r, _ := regexp.Compile(desired + ".*")
+		return r.MatchString(latestEV)
+	}
+
+	// if the version is higher than 6, skip the upstream patch version when comparing.
+	majorVersion, _ := strconv.Atoi(desiredEV[0:1])
+	if majorVersion >= 6 {
+		r, _ := regexp.Compile(desiredEV + ".*")
 		return r.MatchString(latestEV)
 	}
 

--- a/pkg/resource/replication_group/delta_util_test.go
+++ b/pkg/resource/replication_group/delta_util_test.go
@@ -19,6 +19,7 @@ import "github.com/stretchr/testify/require"
 func TestEngineVersionsMatch(t *testing.T) {
 	require := require.New(t)
 
+	require.True(engineVersionsMatch("6.2", "6.2.6"))
 	require.True(engineVersionsMatch("6.x", "6.0.5"))
 	require.False(engineVersionsMatch("13.x", "6.0.6"))
 	require.True(engineVersionsMatch("5.0.3", "5.0.3"))

--- a/pkg/resource/replication_group/delta_util_test.go
+++ b/pkg/resource/replication_group/delta_util_test.go
@@ -19,6 +19,7 @@ import "github.com/stretchr/testify/require"
 func TestEngineVersionsMatch(t *testing.T) {
 	require := require.New(t)
 
+	require.False(engineVersionsMatch("6.3", "6.2.6"))
 	require.True(engineVersionsMatch("6.2", "6.2.6"))
 	require.True(engineVersionsMatch("6.x", "6.0.5"))
 	require.False(engineVersionsMatch("13.x", "6.0.6"))


### PR DESCRIPTION
Issue #, if available:

Description of changes:

The purpose of this changes is to avoid the controller to compare patch versions when Redis version is >=6, since It's managed by AWS. More details [here](https://github.com/aws-controllers-k8s/community/issues/1737). 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
