### PR TITLE
Update template to support watch namespace

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -33,7 +33,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "watch-namespace" -}}
 {{- if eq .Values.installScope "namespace" -}}
-{{- .Release.Namespace -}}
+{{ .Values.watchNamespace | default .Release.Namespace }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -196,6 +196,9 @@
       "type": "string",
       "enum": ["cluster", "namespace"]
     },
+    "watchNamespace": {
+      "type": "string"
+    },    
     "resourceTags": {
       "type": "array",
       "items": {


### PR DESCRIPTION
As the controller runtime supports watching namespaces, we would need to add a support to watch namespaces other than where the controller is deployed. This is a common use case for multi-tenant K8s environments. This PR introduces a `watchNamespace` flag which lets user define the namespaces to be watched by the controller. If left blank, it would take the release namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
