### PR TITLE
Fix horizontal scaling for ReplicationGroups

### DIFF
--- a/pkg/resource/replication_group/post_set_output.go
+++ b/pkg/resource/replication_group/post_set_output.go
@@ -89,6 +89,10 @@ func setNodeGroupConfiguration(
 
 		ko.Spec.NodeGroupConfiguration = nodeGroupConfigurations
 	}
+
+	if respRG.NodeGroups != nil && ko.Spec.NumNodeGroups != nil {
+		*ko.Spec.NumNodeGroups = int64(len(respRG.NodeGroups))
+	}
 }
 
 //TODO: for all the fields here, reevaluate if the latest observed state should always be populated,


### PR DESCRIPTION
This will set the value for the number of node groups of a ReplicationGroup to the value given in the Spec, thereby enabling horizontal scaling.

Fixes aws-controllers-k8s/community#2080.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
