### PR TITLE
Update terminal err codes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-03-27T16:15:51Z"
+  build_date: "2025-03-28T22:44:10Z"
   build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
   go_version: go1.24.1
   version: v0.44.0
@@ -7,7 +7,7 @@ api_directory_checksum: e8ea0ba4a88df803e4ef067a23c8bf95164a6e51
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 6cf2b7211e26d4a764cd0c6e0959cc77b2b6cbed
+  file_checksum: 8004c2ebf1247b2bcb897f3d651cd0948a48c27a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -221,7 +221,6 @@ resources:
       terminal_codes:
         - CacheParameterGroupAlreadyExists
         - CacheParameterGroupQuotaExceeded
-        - InvalidCacheParameterGroupState
         - InvalidGlobalReplicationGroupState
         - InvalidParameterCombination
         - InvalidParameterValue

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -254,7 +254,6 @@ resources:
         - InvalidParameterValue
         - InvalidParameterCombination
         - InvalidUserState
-        - DefaultUserAssociatedToUserGroup
     fields:
       LastRequestedAccessString:
         is_read_only: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -221,7 +221,6 @@ resources:
       terminal_codes:
         - CacheParameterGroupAlreadyExists
         - CacheParameterGroupQuotaExceeded
-        - InvalidCacheParameterGroupState
         - InvalidGlobalReplicationGroupState
         - InvalidParameterCombination
         - InvalidParameterValue

--- a/generator.yaml
+++ b/generator.yaml
@@ -254,7 +254,6 @@ resources:
         - InvalidParameterValue
         - InvalidParameterCombination
         - InvalidUserState
-        - DefaultUserAssociatedToUserGroup
     fields:
       LastRequestedAccessString:
         is_read_only: true

--- a/pkg/resource/cache_parameter_group/sdk.go
+++ b/pkg/resource/cache_parameter_group/sdk.go
@@ -414,7 +414,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	switch terminalErr.ErrorCode() {
 	case "CacheParameterGroupAlreadyExists",
 		"CacheParameterGroupQuotaExceeded",
-		"InvalidCacheParameterGroupState",
 		"InvalidGlobalReplicationGroupState",
 		"InvalidParameterCombination",
 		"InvalidParameterValue":

--- a/pkg/resource/user/sdk.go
+++ b/pkg/resource/user/sdk.go
@@ -601,8 +601,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"DuplicateUserName",
 		"InvalidParameterValue",
 		"InvalidParameterCombination",
-		"InvalidUserState",
-		"DefaultUserAssociatedToUserGroup":
+		"InvalidUserState":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Issue #, if available:
[aws-controllers-k8s/community#2387](https://github.com/aws-controllers-k8s/community/issues/2387)

Description of changes:
Remove following Terminal Error codes:
`user.DefaultUserAssociatedToUserGroup`;
`cache_parameter_group.InvalidCacheParameterGroupState`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
