### PR TITLE
Ignore TransitEncryptionEnabled in modify when unchanged

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-06-11T00:03:37Z"
-  build_hash: e675923dfc54d8b6e09730098c3e3e1056d3c1e9
-  go_version: go1.24.3
-  version: v0.48.0
+  build_date: "2025-06-24T10:48:48Z"
+  build_hash: a488d4e8a9222ed51e5690cb5850beb21cce5a1f
+  go_version: go1.24.2
+  version: v0.48.0-1-ga488d4e
 api_directory_checksum: e7d8480a655968a4f441db9509fd5561aa5eb1c4
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/replication_group/sdk.go
+++ b/pkg/resource/replication_group/sdk.go
@@ -1118,6 +1118,9 @@ func (rm *resourceManager) sdkUpdate(
 	if !delta.DifferentAt("Spec.LogDeliveryConfigurations") {
 		input.LogDeliveryConfigurations = nil
 	}
+	if !delta.DifferentAt("Spec.TransitEncryptionEnabled") {
+		input.TransitEncryptionEnabled = nil
+	}
 	if delta.DifferentAt("UserGroupIDs") {
 		for _, diff := range delta.Differences {
 			if diff.Path.Contains("UserGroupIDs") {

--- a/templates/hooks/replication_group/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/replication_group/sdk_update_post_build_request.go.tpl
@@ -1,6 +1,9 @@
 	if !delta.DifferentAt("Spec.LogDeliveryConfigurations") {
 		input.LogDeliveryConfigurations = nil
 	}
+	if !delta.DifferentAt("Spec.TransitEncryptionEnabled") {
+		input.TransitEncryptionEnabled = nil
+	}
 	if delta.DifferentAt("UserGroupIDs") {
 		for _, diff := range delta.Differences {
 			if diff.Path.Contains("UserGroupIDs") {


### PR DESCRIPTION
If the `TransitEncryptionEnabled` value is unchanged, but added to a ModifyReplicationGroup call, the ElastiCache API will return an errorMessage saying:

> Modification of transit encryption is not supported for access control
> enabled clusters.

This is "fixed" by not setting it, or setting it to nil.

Fixes aws-controllers-k8s/community#2536

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
