### PR TITLE
add node details to status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-08-15T00:05:26Z"
+  build_date: "2025-08-22T20:47:49Z"
   build_hash: b6df33f8c7f55b234555c0b578b8de43c74771a8
-  go_version: go1.24.6
+  go_version: go1.24.5
   version: v0.51.0
 api_directory_checksum: 5a16cea62c98405d3786f1ee1aad22ff3fafc7d6
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: a3aa9d437d76c0a739168005043783103bf199da
+  file_checksum: 8e6d3a835f5f6a46937ced911945d641a2145303
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -79,6 +79,8 @@ resources:
         template_path: hooks/cache_cluster/sdk_create_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/cache_cluster/sdk_delete_pre_build_request.go.tpl
+      sdk_read_many_post_build_request:
+        template_path: hooks/cache_cluster/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/cache_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -79,6 +79,8 @@ resources:
         template_path: hooks/cache_cluster/sdk_create_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/cache_cluster/sdk_delete_pre_build_request.go.tpl
+      sdk_read_many_post_build_request:
+        template_path: hooks/cache_cluster/sdk_read_many_post_build_request.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/cache_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_update_pre_build_request:

--- a/pkg/resource/cache_cluster/hooks.go
+++ b/pkg/resource/cache_cluster/hooks.go
@@ -45,7 +45,6 @@ const (
 var (
 	condMsgCurrentlyDeleting      = "CacheCluster is currently being deleted"
 	condMsgNoDeleteWhileModifying = "Cannot delete CacheCluster while it is being modified"
-	condMsgCurrentlyUpdating      = "CacheCluster is currently being updated"
 )
 
 var (

--- a/pkg/resource/cache_cluster/sdk.go
+++ b/pkg/resource/cache_cluster/sdk.go
@@ -75,6 +75,8 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+	// Include cache node info to get endpoint details for clusters
+	input.ShowCacheNodeInfo = aws.Bool(true)
 	var resp *svcsdk.DescribeCacheClustersOutput
 	resp, err = rm.sdkapi.DescribeCacheClusters(ctx, input)
 	rm.metrics.RecordAPICall("READ_MANY", "DescribeCacheClusters", err)

--- a/templates/hooks/cache_cluster/sdk_read_many_post_build_request.go.tpl
+++ b/templates/hooks/cache_cluster/sdk_read_many_post_build_request.go.tpl
@@ -1,0 +1,2 @@
+	// Include cache node info to get endpoint details for clusters
+	input.ShowCacheNodeInfo = aws.Bool(true)


### PR DESCRIPTION
Description of changes:

The AWS ElastiCache DescribeCacheClusters API requires the `ShowCacheNodeInfo` parameter to be explicitly set to `true` to return cache node details including endpoints. The ACK controller was calling this API without this parameter, resulting in responses that contained cluster metadata but omitted the node details like endpoints.

Added a direct modification to the sdkFind function in `pkg/resource/cache_cluster/sdk.go` to set `ShowCacheNodeInfo = true` on all `DescribeCacheClusters` API calls. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
