### PR TITLE
tests: Ready condition rename for elasticache-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T17:10:48Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-25T05:32:41Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 65127f2f0a24a801fad4e043be37857f0e6bcfb9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/elasticache.services.k8s.aws_cacheclusters.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cacheclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cacheclusters.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cacheparametergroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cachesubnetgroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: replicationgroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverlesscaches.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_serverlesscachesnapshots.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_serverlesscachesnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverlesscachesnapshots.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: snapshots.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: usergroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/config/crd/bases/elasticache.services.k8s.aws_users.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -91,3 +91,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/aws-controllers-k8s/ec2-controller v1.0.7 h1:7MDu2bq8NFKbgzzgHYPFRT7b
 github.com/aws-controllers-k8s/ec2-controller v1.0.7/go.mod h1:PvsQehgncHgcu9FiY13M45+GkVsKI98g7G83SrgH7vY=
 github.com/aws-controllers-k8s/kms-controller v1.0.2 h1:v8nh/oaX/U6spCwBDaWyem7XXpzoP/MnkJyEjNOZN9s=
 github.com/aws-controllers-k8s/kms-controller v1.0.2/go.mod h1:BeoijsyGjJ9G5VcDjpFdxBW0IxaeKXYX497XmUJiPSQ=
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws-controllers-k8s/sns-controller v1.0.11 h1:nnkywTHzO64y7RrrfoPNyYf1TOkkQHtlg+S0jEPKUZ8=
 github.com/aws-controllers-k8s/sns-controller v1.0.11/go.mod h1:ODQIDZR3hHQqcyif4UXVFQfEzTaWU1jqFtVr83K2p9M=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
@@ -90,6 +88,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/elasticache.services.k8s.aws_cacheclusters.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_cacheclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cacheclusters.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_cacheparametergroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_cacheparametergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cacheparametergroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: cachesubnetgroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: replicationgroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverlesscaches.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_serverlesscachesnapshots.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_serverlesscachesnapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverlesscachesnapshots.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_snapshots.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_snapshots.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: snapshots.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_usergroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_usergroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: usergroups.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/elasticache.services.k8s.aws_users.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: users.elasticache.services.k8s.aws
 spec:
   group: elasticache.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/cache_cluster/references.go
+++ b/pkg/resource/cache_cluster/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	snsapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
@@ -207,8 +208,9 @@ func getReferencedResourceState_CacheParameterGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"CacheParameterGroup",
 				namespace, name)
@@ -219,14 +221,14 @@ func getReferencedResourceState_CacheParameterGroup(
 			"CacheParameterGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"CacheParameterGroup",
 			namespace, name)
@@ -290,8 +292,9 @@ func getReferencedResourceState_CacheSubnetGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"CacheSubnetGroup",
 				namespace, name)
@@ -302,14 +305,14 @@ func getReferencedResourceState_CacheSubnetGroup(
 			"CacheSubnetGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"CacheSubnetGroup",
 			namespace, name)
@@ -373,8 +376,9 @@ func getReferencedResourceState_Topic(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Topic",
 				namespace, name)
@@ -385,14 +389,14 @@ func getReferencedResourceState_Topic(
 			"Topic",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Topic",
 			namespace, name)
@@ -456,8 +460,9 @@ func getReferencedResourceState_ReplicationGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"ReplicationGroup",
 				namespace, name)
@@ -468,14 +473,14 @@ func getReferencedResourceState_ReplicationGroup(
 			"ReplicationGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"ReplicationGroup",
 			namespace, name)
@@ -544,8 +549,9 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -556,14 +562,14 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SecurityGroup",
 			namespace, name)
@@ -627,8 +633,9 @@ func getReferencedResourceState_Snapshot(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Snapshot",
 				namespace, name)
@@ -639,14 +646,14 @@ func getReferencedResourceState_Snapshot(
 			"Snapshot",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Snapshot",
 			namespace, name)

--- a/pkg/resource/cache_subnet_group/references.go
+++ b/pkg/resource/cache_subnet_group/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -141,8 +142,9 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -153,14 +155,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)

--- a/pkg/resource/replication_group/references.go
+++ b/pkg/resource/replication_group/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -161,8 +162,9 @@ func getReferencedResourceState_CacheParameterGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"CacheParameterGroup",
 				namespace, name)
@@ -173,14 +175,14 @@ func getReferencedResourceState_CacheParameterGroup(
 			"CacheParameterGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"CacheParameterGroup",
 			namespace, name)
@@ -244,8 +246,9 @@ func getReferencedResourceState_CacheSubnetGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"CacheSubnetGroup",
 				namespace, name)
@@ -256,14 +259,14 @@ func getReferencedResourceState_CacheSubnetGroup(
 			"CacheSubnetGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"CacheSubnetGroup",
 			namespace, name)
@@ -332,8 +335,9 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -344,14 +348,14 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SecurityGroup",
 			namespace, name)

--- a/pkg/resource/serverless_cache/references.go
+++ b/pkg/resource/serverless_cache/references.go
@@ -25,6 +25,7 @@ import (
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -155,8 +156,9 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -167,14 +169,14 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SecurityGroup",
 			namespace, name)
@@ -243,8 +245,9 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -255,14 +258,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)

--- a/pkg/resource/serverless_cache_snapshot/references.go
+++ b/pkg/resource/serverless_cache_snapshot/references.go
@@ -25,6 +25,7 @@ import (
 
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -150,8 +151,9 @@ func getReferencedResourceState_Key(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Key",
 				namespace, name)
@@ -162,14 +164,14 @@ func getReferencedResourceState_Key(
 			"Key",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Key",
 			namespace, name)
@@ -233,8 +235,9 @@ func getReferencedResourceState_ServerlessCache(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"ServerlessCache",
 				namespace, name)
@@ -245,14 +248,14 @@ func getReferencedResourceState_ServerlessCache(
 			"ServerlessCache",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"ServerlessCache",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428

--- a/test/e2e/tests/test_cache_cluster.py
+++ b/test/e2e/tests/test_cache_cluster.py
@@ -70,9 +70,9 @@ def get_and_assert_status(ref: k8s.CustomResourceReference, expected_status: str
     assert cr['status']['cacheClusterStatus'] == expected_status
 
     if expected_synced:
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
     else:
-        condition.assert_not_synced(ref)
+        condition.assert_not_ready(ref)
 
 
 @pytest.fixture(scope="module")

--- a/test/e2e/tests/test_replicationgroup.py
+++ b/test/e2e/tests/test_replicationgroup.py
@@ -171,7 +171,7 @@ class TestReplicationGroup:
     def test_rg_cmd_fromsnapshot(self, rg_cmd_fromsnapshot):
         (reference, _) = rg_cmd_fromsnapshot
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
     def test_rg_invalid_primary(self, make_rg_name, make_replication_group, rg_deletion_waiter):
         input_dict = {
@@ -196,7 +196,7 @@ class TestReplicationGroup:
     def test_rg_update(self, rg_update_input, rg_update):
         (reference, _) = rg_update
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # desired initial state
         cr = k8s.get_resource(reference)
@@ -246,7 +246,7 @@ class TestReplicationGroup:
         _ = k8s.patch_custom_resource(reference, patch)
         sleep(DEFAULT_WAIT_SECS)
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # Assert new state
         resource = k8s.get_resource(reference)
@@ -266,7 +266,7 @@ class TestReplicationGroup:
         LONG_WAIT_SECS = 180
         sleep(LONG_WAIT_SECS)
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # assert new tags
         assert_spec_tags(rg_id, new_tags)
@@ -275,7 +275,7 @@ class TestReplicationGroup:
     def test_rg_fault_tolerance(self, rg_fault_tolerance):
         (reference, _) = rg_fault_tolerance
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # assert initial state
         resource = k8s.get_resource(reference)
@@ -300,7 +300,7 @@ class TestReplicationGroup:
         _ = k8s.patch_custom_resource(reference, patch)
         sleep(DEFAULT_WAIT_SECS)
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # assert new state
         resource = k8s.get_resource(reference)
@@ -313,7 +313,7 @@ class TestReplicationGroup:
         _ = k8s.patch_custom_resource(reference, patch)
         sleep(DEFAULT_WAIT_SECS)
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # assert roles
         resource = k8s.get_resource(reference)
@@ -343,7 +343,7 @@ class TestReplicationGroup:
             "replicationgroup_create_delete", input_dict, input_dict["RG_ID"])
 
         assert k8s.wait_on_condition(
-            reference, "ACK.ResourceSynced", "True", wait_periods=90)
+            reference, "Ready", "True", wait_periods=90)
 
         # assertions after initial creation
         resource = k8s.get_resource(reference)

--- a/test/e2e/tests/test_serverless_cache.py
+++ b/test/e2e/tests/test_serverless_cache.py
@@ -58,9 +58,9 @@ def get_and_assert_status(ref: k8s.CustomResourceReference, expected_status: str
     assert cr['status']['status'] == expected_status
 
     if expected_synced:
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
     else:
-        condition.assert_not_synced(ref)
+        condition.assert_not_ready(ref)
 
 
 @pytest.fixture(scope="module")
@@ -129,7 +129,7 @@ class TestServerlessCache:
         (ref, _) = simple_serverless_cache
         
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=90
+            ref, "Ready", "True", wait_periods=90
         )
         get_and_assert_status(ref, "available", True)
         
@@ -162,7 +162,7 @@ class TestServerlessCache:
         
         # Wait for update to be synced
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=90
+            ref, "Ready", "True", wait_periods=90
         )
         
         # Verify the update was applied
@@ -178,7 +178,7 @@ class TestServerlessCache:
         
         # Wait for the serverless cache to be created and become available
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=90
+            ref, "Ready", "True", wait_periods=90
         )
         get_and_assert_status(ref, "available", True)
         
@@ -206,7 +206,7 @@ class TestServerlessCache:
         
         # Wait for upgrade to be synced
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=90
+            ref, "Ready", "True", wait_periods=90
         )
         
         # Wait for it to be available again after upgrade

--- a/test/e2e/tests/test_serverless_cache_snapshot.py
+++ b/test/e2e/tests/test_serverless_cache_snapshot.py
@@ -64,7 +64,7 @@ def serverless_cache_for_snapshot(elasticache_client):
     
     # Wait for serverless cache to be available
     assert k8s.wait_on_condition(
-        ref, "ACK.ResourceSynced", "True", wait_periods=90
+        ref, "Ready", "True", wait_periods=90
     )
     
     yield ref, cr
@@ -112,7 +112,7 @@ class TestServerlessCacheSnapshot:
         (ref, _) = simple_serverless_cache_snapshot
         
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=120
+            ref, "Ready", "True", wait_periods=120
         )
         
         tag_updates = {

--- a/test/e2e/tests/test_snapshot.py
+++ b/test/e2e/tests/test_snapshot.py
@@ -82,4 +82,4 @@ class TestSnapshot:
     # test create of snapshot while providing KMS key
     def test_snapshot_kms(self, snapshot_kms):
         (reference, _) = snapshot_kms
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=15)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=15)

--- a/test/e2e/tests/test_user.py
+++ b/test/e2e/tests/test_user.py
@@ -115,7 +115,7 @@ class TestUser:
         (reference, resource) = user_nopass
         assert k8s.get_resource_exists(reference)
 
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=5)
         resource = k8s.get_resource(reference)
         assert resource["status"]["lastRequestedAccessString"] == user_nopass_input["ACCESS_STRING"]
 
@@ -124,7 +124,7 @@ class TestUser:
         _ = k8s.patch_custom_resource(reference, user_patch)
         sleep(DEFAULT_WAIT_SECS)
 
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=5)
         resource = k8s.get_resource(reference)
         assert resource["status"]["lastRequestedAccessString"] == new_access_string
 
@@ -133,7 +133,7 @@ class TestUser:
         (reference, resource) = user_password
         assert k8s.get_resource_exists(reference)
 
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=5)
         resource = k8s.get_resource(reference)
         assert resource["status"]["authentication"] is not None
         assert resource["status"]["authentication"]["type_"] == "password"

--- a/test/e2e/tests/test_usergroup.py
+++ b/test/e2e/tests/test_usergroup.py
@@ -66,7 +66,7 @@ def user_group_create(get_user_group_yaml):
 class TestUserGroup:
     def test_user_group_create_update(self, user_group_create, get_user_group_yaml, bootstrap_resources):
         (reference, resource) = user_group_create
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=15)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=15)
 
         # Update the usergroup to include one more user
         updated_user_group = get_user_group_yaml(reference.name)
@@ -74,7 +74,7 @@ class TestUserGroup:
 
         k8s.patch_custom_resource(reference, updated_user_group)
 
-        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True", wait_periods=15)
+        assert k8s.wait_on_condition(reference, "Ready", "True", wait_periods=15)
         resource = k8s.get_resource(reference)
         assert len(resource["spec"]["userIDs"]) == 2
         assert resource["status"]["status"] == "active"


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._