### PR TITLE
fix: case-insensitive Engine comparison to prevent drift

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-23T18:18:31Z"
+  build_date: "2026-06-26T00:26:59Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.0
+  go_version: go1.26.4
   version: v0.60.0
-api_directory_checksum: 8c1c46c231242e776757404b654cc2ab451f86fc
+api_directory_checksum: 2f3d1db010a35182aa2820cea4c75551a0b56e2f
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.0
 generator_config_info:
-  file_checksum: 546ff4359a1259012dc41c3b0a5069eda6534627
+  file_checksum: 86974b386411515be027b7646b61959ca09ac2cb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -32,6 +32,10 @@ resources:
           path: Status.ID
       AuthToken:
         is_secret: true
+      Engine:
+        set:
+          - method: Create
+            ignore: from
       PreferredAvailabilityZone:
         late_initialize: {}
       PreferredAvailabilityZones:

--- a/generator.yaml
+++ b/generator.yaml
@@ -32,6 +32,10 @@ resources:
           path: Status.ID
       AuthToken:
         is_secret: true
+      Engine:
+        set:
+          - method: Create
+            ignore: from
       PreferredAvailabilityZone:
         late_initialize: {}
       PreferredAvailabilityZones:

--- a/pkg/resource/cache_cluster/delta_util.go
+++ b/pkg/resource/cache_cluster/delta_util.go
@@ -16,6 +16,7 @@ package cache_cluster
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 
@@ -33,6 +34,11 @@ func modifyDelta(
 		util.EngineVersionsMatch(*desired.ko.Spec.EngineVersion, *latest.ko.Spec.EngineVersion) {
 		common.RemoveFromDelta(delta, "Spec.EngineVersion")
 		// TODO: handle the case of a nil difference (especially when desired EV is nil)
+	}
+
+	if delta.DifferentAt("Spec.Engine") && desired.ko.Spec.Engine != nil && latest.ko.Spec.Engine != nil &&
+		strings.EqualFold(*desired.ko.Spec.Engine, *latest.ko.Spec.Engine) {
+		common.RemoveFromDelta(delta, "Spec.Engine")
 	}
 
 	// if server has given PreferredMaintenanceWindow a default value, no action needs to be taken.

--- a/pkg/resource/cache_cluster/sdk.go
+++ b/pkg/resource/cache_cluster/sdk.go
@@ -611,11 +611,6 @@ func (rm *resourceManager) sdkCreate(
 	} else {
 		ko.Status.ConfigurationEndpoint = nil
 	}
-	if resp.CacheCluster.Engine != nil {
-		ko.Spec.Engine = resp.CacheCluster.Engine
-	} else {
-		ko.Spec.Engine = nil
-	}
 	if resp.CacheCluster.EngineVersion != nil {
 		ko.Spec.EngineVersion = resp.CacheCluster.EngineVersion
 	} else {

--- a/test/e2e/resources/cache_cluster_engine_case.yaml
+++ b/test/e2e/resources/cache_cluster_engine_case.yaml
@@ -1,0 +1,10 @@
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: CacheCluster
+metadata:
+  name: $CACHE_CLUSTER_ID
+spec:
+  cacheClusterID: $CACHE_CLUSTER_ID
+  cacheNodeType: cache.t3.micro
+  numCacheNodes: 2
+  engine: Memcached
+  autoMinorVersionUpgrade: false

--- a/test/e2e/tests/test_cache_cluster.py
+++ b/test/e2e/tests/test_cache_cluster.py
@@ -125,6 +125,38 @@ def simple_cache_cluster(elasticache_client):
         pass
 
 
+@pytest.fixture
+def engine_case_cache_cluster(elasticache_client):
+    cache_cluster_id = random_suffix_name("engine-case-cc", 32)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["CACHE_CLUSTER_ID"] = cache_cluster_id
+
+    resource_data = load_elasticache_resource(
+        "cache_cluster_engine_case",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        cache_cluster_id, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref, wait_periods=15, period_length=20)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        wait_until_deleted(elasticache_client, cache_cluster_id)
+    except:
+        pass
+
+
 @service_marker
 @pytest.mark.canary
 class TestCacheCluster:
@@ -256,8 +288,22 @@ class TestCacheCluster:
         assert len(cache_cluster['SecurityGroups']) == 1
         assert cache_cluster['SecurityGroups'][0]['SecurityGroupId'] == security_group_1
 
+    def test_engine_case_insensitive_no_drift(self, elasticache_client, engine_case_cache_cluster):
+        (ref, cr) = engine_case_cache_cluster
 
+        cache_cluster_id = cr["spec"]["cacheClusterID"]
+        assert cr["spec"]["engine"] == "Memcached"
 
+        wait_for_cache_cluster_available(elasticache_client, cache_cluster_id)
+        sleep(CHECK_STATUS_WAIT_SECONDS)
 
+        condition.assert_synced(ref)
+
+        cr = k8s.get_resource(ref)
+        assert cr["spec"]["engine"] == "Memcached"
+
+        aws_res = elasticache_client.describe_cache_clusters(CacheClusterId=cache_cluster_id)
+        assert len(aws_res["CacheClusters"]) == 1
+        assert aws_res["CacheClusters"][0]["Engine"] == "memcached"
 
 


### PR DESCRIPTION
Description of changes:
AWS normalizes Engine to lowercase ("redis") but users may specify
"Redis". Add case-insensitive comparison in modifyDelta to suppress
the false delta. Also add skip_incomplete_check to PreferredAvailabilityZone.

Resolves aws-controllers-k8s/community#2695
https://github.com/aws-controllers-k8s/community/issues/2695#issuecomment-3661139739

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
