### PR TITLE
Add cross-resource references for 8 fields across 4 resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:39:32Z"
+  build_date: "2026-08-10T20:26:07Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: 2f3d1db010a35182aa2820cea4c75551a0b56e2f
+api_directory_checksum: da2f32a31cf6801e56ad4dc761ebb7ab1282cbc2
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.0
 generator_config_info:
-  file_checksum: 86974b386411515be027b7646b61959ca09ac2cb
+  file_checksum: c77975c0aacaedcd10702c6edc370fa6af8bcfeb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-10T20:26:07Z"
+  build_date: "2026-08-10T22:28:11Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
   go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: da2f32a31cf6801e56ad4dc761ebb7ab1282cbc2
+api_directory_checksum: 3e5e5dc3d631c394a8f2f3e49e0a90ed66631586
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.0
 generator_config_info:
-  file_checksum: c77975c0aacaedcd10702c6edc370fa6af8bcfeb
+  file_checksum: 03e9653b96b750ed96019c35ad53b18b63644e4f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -170,6 +170,20 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      NotificationTopicARN:
+        references:
+          service_name: sns
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
+      UserGroupIDs:
+        references:
+          resource: UserGroup
+          path: Spec.UserGroupID
+      SnapshotName:
+        is_immutable: true
+        references:
+          resource: Snapshot
+          path: Spec.SnapshotName
       Events:
         is_read_only: true
         from:
@@ -238,10 +252,17 @@ resources:
         references:
           resource: ReplicationGroup
           path: Spec.ReplicationGroupID
+      CacheClusterID:
+        references:
+          resource: CacheCluster
+          path: Spec.CacheClusterID
       SourceSnapshotName:
         from:
           operation: CopySnapshot
           path: SourceSnapshotName
+        references:
+          resource: Snapshot
+          path: Spec.SnapshotName
     update_operation:
       custom_method_name: customUpdateSnapshot
   CacheParameterGroup:
@@ -323,6 +344,11 @@ resources:
         - DefaultUserRequired
         - UserGroupQuotaExceededFault
         - TagQuotaPerResourceExceeded
+    fields:
+      UserIDs:
+        references:
+          resource: User
+          path: Spec.UserID
     hooks:
       sdk_update_post_build_request:
         template_path: hooks/user_group/sdk_update_post_build_request.go.tpl
@@ -347,6 +373,20 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      KMSKeyID:
+        is_immutable: true
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      UserGroupID:
+        references:
+          resource: UserGroup
+          path: Spec.UserGroupID
+      SnapshotARNsToRestore:
+        references:
+          resource: ServerlessCacheSnapshot
+          path: Status.ACKResourceMetadata.ARN
     synced:
       when:
       - path: Status.Status

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -383,10 +383,6 @@ resources:
         references:
           resource: UserGroup
           path: Spec.UserGroupID
-      SnapshotARNsToRestore:
-        references:
-          resource: ServerlessCacheSnapshot
-          path: Status.ACKResourceMetadata.ARN
     synced:
       when:
       - path: Status.Status

--- a/apis/v1alpha1/replication_group.go
+++ b/apis/v1alpha1/replication_group.go
@@ -200,7 +200,8 @@ type ReplicationGroupSpec struct {
 	// (SNS) topic to which notifications are sent.
 	//
 	// The Amazon SNS topic owner must be the same as the cluster owner.
-	NotificationTopicARN *string `json:"notificationTopicARN,omitempty"`
+	NotificationTopicARN *string                                  `json:"notificationTopicARN,omitempty"`
+	NotificationTopicRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"notificationTopicRef,omitempty"`
 	// An optional parameter that specifies the number of node groups (shards) for
 	// this Valkey or Redis OSS (cluster mode enabled) replication group. For Valkey
 	// or Redis OSS (cluster mode disabled) either omit this parameter or set it
@@ -289,7 +290,9 @@ type ReplicationGroupSpec struct {
 	// The name of a snapshot from which to restore data into the new replication
 	// group. The snapshot status changes to restoring while the new replication
 	// group is being created.
-	SnapshotName *string `json:"snapshotName,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
+	SnapshotName *string                                  `json:"snapshotName,omitempty"`
+	SnapshotRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"snapshotRef,omitempty"`
 	// The number of days for which ElastiCache retains automatic snapshots before
 	// deleting them. For example, if you set SnapshotRetentionLimit to 5, a snapshot
 	// that was taken today is retained for 5 days before being deleted.
@@ -326,7 +329,8 @@ type ReplicationGroupSpec struct {
 	// an AuthToken, and a CacheSubnetGroup.
 	TransitEncryptionEnabled *bool `json:"transitEncryptionEnabled,omitempty"`
 	// The user group to associate with the replication group.
-	UserGroupIDs []*string `json:"userGroupIDs,omitempty"`
+	UserGroupIDs  []*string                                  `json:"userGroupIDs,omitempty"`
+	UserGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"userGroupRefs,omitempty"`
 }
 
 // ReplicationGroupStatus defines the observed state of ReplicationGroup

--- a/apis/v1alpha1/serverless_cache.go
+++ b/apis/v1alpha1/serverless_cache.go
@@ -42,7 +42,9 @@ type ServerlessCacheSpec struct {
 	Engine *string `json:"engine"`
 	// ARN of the customer managed key for encrypting the data at rest. If no KMS
 	// key is provided, a default service key is used.
-	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
+	KMSKeyID  *string                                  `json:"kmsKeyID,omitempty"`
+	KMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsKeyRef,omitempty"`
 	// The version of the cache engine that will be used to create the serverless
 	// cache.
 	MajorEngineVersion *string `json:"majorEngineVersion,omitempty"`
@@ -58,7 +60,8 @@ type ServerlessCacheSpec struct {
 	ServerlessCacheName *string `json:"serverlessCacheName"`
 	// The ARN(s) of the snapshot that the new serverless cache will be created
 	// from. Available for Valkey, Redis OSS and Serverless Memcached only.
-	SnapshotARNsToRestore []*string `json:"snapshotARNsToRestore,omitempty"`
+	SnapshotARNsToRestore     []*string                                  `json:"snapshotARNsToRestore,omitempty"`
+	SnapshotARNsToRestoreRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"snapshotARNsToRestoreRefs,omitempty"`
 	// The number of snapshots that will be retained for the serverless cache that
 	// is being created. As new snapshots beyond this limit are added, the oldest
 	// snapshots will be deleted on a rolling basis. Available for Valkey, Redis
@@ -73,7 +76,8 @@ type ServerlessCacheSpec struct {
 	Tags []*Tag `json:"tags,omitempty"`
 	// The identifier of the UserGroup to be associated with the serverless cache.
 	// Available for Valkey and Redis OSS only. Default is NULL.
-	UserGroupID *string `json:"userGroupID,omitempty"`
+	UserGroupID  *string                                  `json:"userGroupID,omitempty"`
+	UserGroupRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"userGroupRef,omitempty"`
 }
 
 // ServerlessCacheStatus defines the observed state of ServerlessCache

--- a/apis/v1alpha1/serverless_cache.go
+++ b/apis/v1alpha1/serverless_cache.go
@@ -60,8 +60,7 @@ type ServerlessCacheSpec struct {
 	ServerlessCacheName *string `json:"serverlessCacheName"`
 	// The ARN(s) of the snapshot that the new serverless cache will be created
 	// from. Available for Valkey, Redis OSS and Serverless Memcached only.
-	SnapshotARNsToRestore     []*string                                  `json:"snapshotARNsToRestore,omitempty"`
-	SnapshotARNsToRestoreRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"snapshotARNsToRestoreRefs,omitempty"`
+	SnapshotARNsToRestore []*string `json:"snapshotARNsToRestore,omitempty"`
 	// The number of snapshots that will be retained for the serverless cache that
 	// is being created. As new snapshots beyond this limit are added, the oldest
 	// snapshots will be deleted on a rolling basis. Available for Valkey, Redis

--- a/apis/v1alpha1/snapshot.go
+++ b/apis/v1alpha1/snapshot.go
@@ -28,7 +28,8 @@ type SnapshotSpec struct {
 
 	// The identifier of an existing cluster. The snapshot is created from this
 	// cluster.
-	CacheClusterID *string `json:"cacheClusterID,omitempty"`
+	CacheClusterID  *string                                  `json:"cacheClusterID,omitempty"`
+	CacheClusterRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"cacheClusterRef,omitempty"`
 	// The ID of the KMS key used to encrypt the snapshot.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	KMSKeyID  *string                                  `json:"kmsKeyID,omitempty"`
@@ -41,7 +42,8 @@ type SnapshotSpec struct {
 	// +kubebuilder:validation:Required
 	SnapshotName *string `json:"snapshotName"`
 	// The name of an existing snapshot from which to make a copy.
-	SourceSnapshotName *string `json:"sourceSnapshotName,omitempty"`
+	SourceSnapshotName *string                                  `json:"sourceSnapshotName,omitempty"`
+	SourceSnapshotRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"sourceSnapshotRef,omitempty"`
 	// A list of tags to be added to this resource. A tag is a key-value pair. A
 	// tag key must be accompanied by a tag value, although null is accepted.
 	Tags []*Tag `json:"tags,omitempty"`

--- a/apis/v1alpha1/user_group.go
+++ b/apis/v1alpha1/user_group.go
@@ -38,7 +38,8 @@ type UserGroupSpec struct {
 	// +kubebuilder:validation:Required
 	UserGroupID *string `json:"userGroupID"`
 	// The list of user IDs that belong to the user group.
-	UserIDs []*string `json:"userIDs,omitempty"`
+	UserIDs  []*string                                  `json:"userIDs,omitempty"`
+	UserRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"userRefs,omitempty"`
 }
 
 // UserGroupStatus defines the observed state of UserGroup

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2861,6 +2861,11 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NotificationTopicRef != nil {
+		in, out := &in.NotificationTopicRef, &out.NotificationTopicRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NumNodeGroups != nil {
 		in, out := &in.NumNodeGroups, &out.NumNodeGroups
 		*out = new(int64)
@@ -2940,6 +2945,11 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SnapshotRef != nil {
+		in, out := &in.SnapshotRef, &out.SnapshotRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SnapshotRetentionLimit != nil {
 		in, out := &in.SnapshotRetentionLimit, &out.SnapshotRetentionLimit
 		*out = new(int64)
@@ -2974,6 +2984,17 @@ func (in *ReplicationGroupSpec) DeepCopyInto(out *ReplicationGroupSpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.UserGroupRefs != nil {
+		in, out := &in.UserGroupRefs, &out.UserGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -3922,6 +3943,11 @@ func (in *ServerlessCacheSpec) DeepCopyInto(out *ServerlessCacheSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KMSKeyRef != nil {
+		in, out := &in.KMSKeyRef, &out.KMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MajorEngineVersion != nil {
 		in, out := &in.MajorEngineVersion, &out.MajorEngineVersion
 		*out = new(string)
@@ -3962,6 +3988,17 @@ func (in *ServerlessCacheSpec) DeepCopyInto(out *ServerlessCacheSpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.SnapshotARNsToRestoreRefs != nil {
+		in, out := &in.SnapshotARNsToRestoreRefs, &out.SnapshotARNsToRestoreRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -4007,6 +4044,11 @@ func (in *ServerlessCacheSpec) DeepCopyInto(out *ServerlessCacheSpec) {
 		in, out := &in.UserGroupID, &out.UserGroupID
 		*out = new(string)
 		**out = **in
+	}
+	if in.UserGroupRef != nil {
+		in, out := &in.UserGroupRef, &out.UserGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -4330,6 +4372,11 @@ func (in *SnapshotSpec) DeepCopyInto(out *SnapshotSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CacheClusterRef != nil {
+		in, out := &in.CacheClusterRef, &out.CacheClusterRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.KMSKeyID != nil {
 		in, out := &in.KMSKeyID, &out.KMSKeyID
 		*out = new(string)
@@ -4359,6 +4406,11 @@ func (in *SnapshotSpec) DeepCopyInto(out *SnapshotSpec) {
 		in, out := &in.SourceSnapshotName, &out.SourceSnapshotName
 		*out = new(string)
 		**out = **in
+	}
+	if in.SourceSnapshotRef != nil {
+		in, out := &in.SourceSnapshotRef, &out.SourceSnapshotRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
@@ -5048,6 +5100,17 @@ func (in *UserGroupSpec) DeepCopyInto(out *UserGroupSpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.UserRefs != nil {
+		in, out := &in.UserRefs, &out.UserRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -3991,17 +3991,6 @@ func (in *ServerlessCacheSpec) DeepCopyInto(out *ServerlessCacheSpec) {
 			}
 		}
 	}
-	if in.SnapshotARNsToRestoreRefs != nil {
-		in, out := &in.SnapshotARNsToRestoreRefs, &out.SnapshotARNsToRestoreRefs
-		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
-				(*in).DeepCopyInto(*out)
-			}
-		}
-	}
 	if in.SnapshotRetentionLimit != nil {
 		in, out := &in.SnapshotRetentionLimit, &out.SnapshotRetentionLimit
 		*out = new(int64)

--- a/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -378,6 +378,23 @@ spec:
 
                   The Amazon SNS topic owner must be the same as the cluster owner.
                 type: string
+              notificationTopicRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               numNodeGroups:
                 description: |-
                   An optional parameter that specifies the number of node groups (shards) for
@@ -512,6 +529,26 @@ spec:
                   group. The snapshot status changes to restoring while the new replication
                   group is being created.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
+              snapshotRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               snapshotRetentionLimit:
                 description: |-
                   The number of days for which ElastiCache retains automatic snapshots before
@@ -574,6 +611,25 @@ spec:
                 description: The user group to associate with the replication group.
                 items:
                   type: string
+                type: array
+              userGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - description

--- a/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -107,6 +107,26 @@ spec:
                   ARN of the customer managed key for encrypting the data at rest. If no KMS
                   key is provided, a default service key is used.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
+              kmsKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               majorEngineVersion:
                 description: |-
                   The version of the cache engine that will be used to create the serverless
@@ -151,6 +171,25 @@ spec:
                   from. Available for Valkey, Redis OSS and Serverless Memcached only.
                 items:
                   type: string
+                type: array
+              snapshotARNsToRestoreRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
                 type: array
               snapshotRetentionLimit:
                 description: |-
@@ -210,6 +249,23 @@ spec:
                   The identifier of the UserGroup to be associated with the serverless cache.
                   Available for Valkey and Redis OSS only. Default is NULL.
                 type: string
+              userGroupRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - engine
             - serverlessCacheName

--- a/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -172,25 +172,6 @@ spec:
                 items:
                   type: string
                 type: array
-              snapshotARNsToRestoreRefs:
-                items:
-                  description: "AWSResourceReferenceWrapper provides a wrapper around
-                    *AWSResourceReference\ntype to provide more user friendly syntax
-                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                    \ name: my-api"
-                  properties:
-                    from:
-                      description: |-
-                        AWSResourceReference provides all the values necessary to reference another
-                        k8s resource for finding the identifier(Id/ARN/Name)
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      type: object
-                  type: object
-                type: array
               snapshotRetentionLimit:
                 description: |-
                   The number of snapshots that will be retained for the serverless cache that

--- a/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_snapshots.yaml
@@ -48,6 +48,23 @@ spec:
                   The identifier of an existing cluster. The snapshot is created from this
                   cluster.
                 type: string
+              cacheClusterRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               kmsKeyID:
                 description: The ID of the KMS key used to encrypt the snapshot.
                 type: string
@@ -100,6 +117,23 @@ spec:
                 description: The name of an existing snapshot from which to make a
                   copy.
                 type: string
+              sourceSnapshotRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   A list of tags to be added to this resource. A tag is a key-value pair. A

--- a/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
+++ b/config/crd/bases/elasticache.services.k8s.aws_usergroups.yaml
@@ -72,6 +72,25 @@ spec:
                 items:
                   type: string
                 type: array
+              userRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
             required:
             - engine
             - userGroupID

--- a/generator.yaml
+++ b/generator.yaml
@@ -170,6 +170,20 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      NotificationTopicARN:
+        references:
+          service_name: sns
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
+      UserGroupIDs:
+        references:
+          resource: UserGroup
+          path: Spec.UserGroupID
+      SnapshotName:
+        is_immutable: true
+        references:
+          resource: Snapshot
+          path: Spec.SnapshotName
       Events:
         is_read_only: true
         from:
@@ -238,10 +252,17 @@ resources:
         references:
           resource: ReplicationGroup
           path: Spec.ReplicationGroupID
+      CacheClusterID:
+        references:
+          resource: CacheCluster
+          path: Spec.CacheClusterID
       SourceSnapshotName:
         from:
           operation: CopySnapshot
           path: SourceSnapshotName
+        references:
+          resource: Snapshot
+          path: Spec.SnapshotName
     update_operation:
       custom_method_name: customUpdateSnapshot
   CacheParameterGroup:
@@ -323,6 +344,11 @@ resources:
         - DefaultUserRequired
         - UserGroupQuotaExceededFault
         - TagQuotaPerResourceExceeded
+    fields:
+      UserIDs:
+        references:
+          resource: User
+          path: Spec.UserID
     hooks:
       sdk_update_post_build_request:
         template_path: hooks/user_group/sdk_update_post_build_request.go.tpl
@@ -347,6 +373,20 @@ resources:
           service_name: ec2
           resource: Subnet
           path: Status.SubnetID
+      KMSKeyID:
+        is_immutable: true
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      UserGroupID:
+        references:
+          resource: UserGroup
+          path: Spec.UserGroupID
+      SnapshotARNsToRestore:
+        references:
+          resource: ServerlessCacheSnapshot
+          path: Status.ACKResourceMetadata.ARN
     synced:
       when:
       - path: Status.Status

--- a/generator.yaml
+++ b/generator.yaml
@@ -383,10 +383,6 @@ resources:
         references:
           resource: UserGroup
           path: Spec.UserGroupID
-      SnapshotARNsToRestore:
-        references:
-          resource: ServerlessCacheSnapshot
-          path: Status.ACKResourceMetadata.ARN
     synced:
       when:
       - path: Status.Status

--- a/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -378,6 +378,23 @@ spec:
 
                   The Amazon SNS topic owner must be the same as the cluster owner.
                 type: string
+              notificationTopicRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               numNodeGroups:
                 description: |-
                   An optional parameter that specifies the number of node groups (shards) for
@@ -512,6 +529,26 @@ spec:
                   group. The snapshot status changes to restoring while the new replication
                   group is being created.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
+              snapshotRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               snapshotRetentionLimit:
                 description: |-
                   The number of days for which ElastiCache retains automatic snapshots before
@@ -574,6 +611,25 @@ spec:
                 description: The user group to associate with the replication group.
                 items:
                   type: string
+                type: array
+              userGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - description

--- a/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -107,6 +107,26 @@ spec:
                   ARN of the customer managed key for encrypting the data at rest. If no KMS
                   key is provided, a default service key is used.
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
+              kmsKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               majorEngineVersion:
                 description: |-
                   The version of the cache engine that will be used to create the serverless
@@ -151,6 +171,25 @@ spec:
                   from. Available for Valkey, Redis OSS and Serverless Memcached only.
                 items:
                   type: string
+                type: array
+              snapshotARNsToRestoreRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
                 type: array
               snapshotRetentionLimit:
                 description: |-
@@ -210,6 +249,23 @@ spec:
                   The identifier of the UserGroup to be associated with the serverless cache.
                   Available for Valkey and Redis OSS only. Default is NULL.
                 type: string
+              userGroupRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
             required:
             - engine
             - serverlessCacheName

--- a/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_serverlesscaches.yaml
@@ -172,25 +172,6 @@ spec:
                 items:
                   type: string
                 type: array
-              snapshotARNsToRestoreRefs:
-                items:
-                  description: "AWSResourceReferenceWrapper provides a wrapper around
-                    *AWSResourceReference\ntype to provide more user friendly syntax
-                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                    \ name: my-api"
-                  properties:
-                    from:
-                      description: |-
-                        AWSResourceReference provides all the values necessary to reference another
-                        k8s resource for finding the identifier(Id/ARN/Name)
-                      properties:
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      type: object
-                  type: object
-                type: array
               snapshotRetentionLimit:
                 description: |-
                   The number of snapshots that will be retained for the serverless cache that

--- a/helm/crds/elasticache.services.k8s.aws_snapshots.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_snapshots.yaml
@@ -48,6 +48,23 @@ spec:
                   The identifier of an existing cluster. The snapshot is created from this
                   cluster.
                 type: string
+              cacheClusterRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               kmsKeyID:
                 description: The ID of the KMS key used to encrypt the snapshot.
                 type: string
@@ -100,6 +117,23 @@ spec:
                 description: The name of an existing snapshot from which to make a
                   copy.
                 type: string
+              sourceSnapshotRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   A list of tags to be added to this resource. A tag is a key-value pair. A

--- a/helm/crds/elasticache.services.k8s.aws_usergroups.yaml
+++ b/helm/crds/elasticache.services.k8s.aws_usergroups.yaml
@@ -72,6 +72,25 @@ spec:
                 items:
                   type: string
                 type: array
+              userRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
             required:
             - engine
             - userGroupID

--- a/pkg/resource/replication_group/delta.go
+++ b/pkg/resource/replication_group/delta.go
@@ -156,6 +156,9 @@ func newResourceDelta(
 			delta.Add("Spec.NotificationTopicARN", a.ko.Spec.NotificationTopicARN, b.ko.Spec.NotificationTopicARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.NotificationTopicRef, b.ko.Spec.NotificationTopicRef) {
+		delta.Add("Spec.NotificationTopicRef", a.ko.Spec.NotificationTopicRef, b.ko.Spec.NotificationTopicRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.NumNodeGroups, b.ko.Spec.NumNodeGroups) {
 		delta.Add("Spec.NumNodeGroups", a.ko.Spec.NumNodeGroups, b.ko.Spec.NumNodeGroups)
 	} else if a.ko.Spec.NumNodeGroups != nil && b.ko.Spec.NumNodeGroups != nil {
@@ -222,6 +225,9 @@ func newResourceDelta(
 			delta.Add("Spec.SnapshotName", a.ko.Spec.SnapshotName, b.ko.Spec.SnapshotName)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SnapshotRef, b.ko.Spec.SnapshotRef) {
+		delta.Add("Spec.SnapshotRef", a.ko.Spec.SnapshotRef, b.ko.Spec.SnapshotRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit) {
 		delta.Add("Spec.SnapshotRetentionLimit", a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit)
 	} else if a.ko.Spec.SnapshotRetentionLimit != nil && b.ko.Spec.SnapshotRetentionLimit != nil {
@@ -254,6 +260,9 @@ func newResourceDelta(
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.UserGroupIDs, b.ko.Spec.UserGroupIDs) {
 			delta.Add("Spec.UserGroupIDs", a.ko.Spec.UserGroupIDs, b.ko.Spec.UserGroupIDs)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.UserGroupRefs, b.ko.Spec.UserGroupRefs) {
+		delta.Add("Spec.UserGroupRefs", a.ko.Spec.UserGroupRefs, b.ko.Spec.UserGroupRefs)
 	}
 
 	modifyDelta(delta, a, b)

--- a/pkg/resource/replication_group/references.go
+++ b/pkg/resource/replication_group/references.go
@@ -29,12 +29,16 @@ import (
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	snsapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
 )
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics,verbs=get;list
+// +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
@@ -58,8 +62,20 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.KMSKeyID = nil
 	}
 
+	if ko.Spec.NotificationTopicRef != nil {
+		ko.Spec.NotificationTopicARN = nil
+	}
+
 	if len(ko.Spec.SecurityGroupRefs) > 0 {
 		ko.Spec.SecurityGroupIDs = nil
+	}
+
+	if ko.Spec.SnapshotRef != nil {
+		ko.Spec.SnapshotName = nil
+	}
+
+	if len(ko.Spec.UserGroupRefs) > 0 {
+		ko.Spec.UserGroupIDs = nil
 	}
 
 	return &resource{ko}
@@ -99,7 +115,25 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForNotificationTopicARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForSecurityGroupIDs(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSnapshotName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForUserGroupIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -124,8 +158,20 @@ func validateReferenceFields(ko *svcapitypes.ReplicationGroup) error {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
 	}
 
+	if ko.Spec.NotificationTopicRef != nil && ko.Spec.NotificationTopicARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("NotificationTopicARN", "NotificationTopicRef")
+	}
+
 	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroupIDs", "SecurityGroupRefs")
+	}
+
+	if ko.Spec.SnapshotRef != nil && ko.Spec.SnapshotName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SnapshotName", "SnapshotRef")
+	}
+
+	if len(ko.Spec.UserGroupRefs) > 0 && len(ko.Spec.UserGroupIDs) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("UserGroupIDs", "UserGroupRefs")
 	}
 	return nil
 }
@@ -403,6 +449,97 @@ func getReferencedResourceState_Key(
 	return nil
 }
 
+// resolveReferenceForNotificationTopicARN reads the resource referenced
+// from NotificationTopicRef field and sets the NotificationTopicARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForNotificationTopicARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ReplicationGroup,
+) (hasReferences bool, err error) {
+	if ko.Spec.NotificationTopicRef != nil && ko.Spec.NotificationTopicRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.NotificationTopicRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: NotificationTopicRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &snsapitypes.Topic{}
+		if err := getReferencedResourceState_Topic(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.NotificationTopicARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Topic looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Topic(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *snsapitypes.Topic,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Topic",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Topic",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Topic",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Topic",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
 // resolveReferenceForSecurityGroupIDs reads the resource referenced
 // from SecurityGroupRefs field and sets the SecurityGroupIDs
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -495,6 +632,193 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name,
 			"Status.ID")
+	}
+	return nil
+}
+
+// resolveReferenceForSnapshotName reads the resource referenced
+// from SnapshotRef field and sets the SnapshotName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSnapshotName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ReplicationGroup,
+) (hasReferences bool, err error) {
+	if ko.Spec.SnapshotRef != nil && ko.Spec.SnapshotRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SnapshotRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SnapshotRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Snapshot{}
+		if err := getReferencedResourceState_Snapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SnapshotName = (*string)(obj.Spec.SnapshotName)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Snapshot looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Snapshot(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Snapshot,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Snapshot",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Snapshot",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Snapshot",
+			namespace, name)
+	}
+	if obj.Spec.SnapshotName == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Snapshot",
+			namespace, name,
+			"Spec.SnapshotName")
+	}
+	return nil
+}
+
+// resolveReferenceForUserGroupIDs reads the resource referenced
+// from UserGroupRefs field and sets the UserGroupIDs
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForUserGroupIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ReplicationGroup,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.UserGroupRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: UserGroupRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &svcapitypes.UserGroup{}
+			if err := getReferencedResourceState_UserGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.UserGroupIDs == nil {
+				ko.Spec.UserGroupIDs = make([]*string, 0, 1)
+			}
+			ko.Spec.UserGroupIDs = append(ko.Spec.UserGroupIDs, (*string)(obj.Spec.UserGroupID))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_UserGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_UserGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.UserGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"UserGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"UserGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"UserGroup",
+			namespace, name)
+	}
+	if obj.Spec.UserGroupID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"UserGroup",
+			namespace, name,
+			"Spec.UserGroupID")
 	}
 	return nil
 }

--- a/pkg/resource/serverless_cache/delta.go
+++ b/pkg/resource/serverless_cache/delta.go
@@ -151,9 +151,6 @@ func newResourceDelta(
 			delta.Add("Spec.SnapshotARNsToRestore", a.ko.Spec.SnapshotARNsToRestore, b.ko.Spec.SnapshotARNsToRestore)
 		}
 	}
-	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SnapshotARNsToRestoreRefs, b.ko.Spec.SnapshotARNsToRestoreRefs) {
-		delta.Add("Spec.SnapshotARNsToRestoreRefs", a.ko.Spec.SnapshotARNsToRestoreRefs, b.ko.Spec.SnapshotARNsToRestoreRefs)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit) {
 		delta.Add("Spec.SnapshotRetentionLimit", a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit)
 	} else if a.ko.Spec.SnapshotRetentionLimit != nil && b.ko.Spec.SnapshotRetentionLimit != nil {

--- a/pkg/resource/serverless_cache/delta.go
+++ b/pkg/resource/serverless_cache/delta.go
@@ -117,6 +117,9 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef) {
+		delta.Add("Spec.KMSKeyRef", a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MajorEngineVersion, b.ko.Spec.MajorEngineVersion) {
 		delta.Add("Spec.MajorEngineVersion", a.ko.Spec.MajorEngineVersion, b.ko.Spec.MajorEngineVersion)
 	} else if a.ko.Spec.MajorEngineVersion != nil && b.ko.Spec.MajorEngineVersion != nil {
@@ -148,6 +151,9 @@ func newResourceDelta(
 			delta.Add("Spec.SnapshotARNsToRestore", a.ko.Spec.SnapshotARNsToRestore, b.ko.Spec.SnapshotARNsToRestore)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SnapshotARNsToRestoreRefs, b.ko.Spec.SnapshotARNsToRestoreRefs) {
+		delta.Add("Spec.SnapshotARNsToRestoreRefs", a.ko.Spec.SnapshotARNsToRestoreRefs, b.ko.Spec.SnapshotARNsToRestoreRefs)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit) {
 		delta.Add("Spec.SnapshotRetentionLimit", a.ko.Spec.SnapshotRetentionLimit, b.ko.Spec.SnapshotRetentionLimit)
 	} else if a.ko.Spec.SnapshotRetentionLimit != nil && b.ko.Spec.SnapshotRetentionLimit != nil {
@@ -176,6 +182,9 @@ func newResourceDelta(
 		if *a.ko.Spec.UserGroupID != *b.ko.Spec.UserGroupID {
 			delta.Add("Spec.UserGroupID", a.ko.Spec.UserGroupID, b.ko.Spec.UserGroupID)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.UserGroupRef, b.ko.Spec.UserGroupRef) {
+		delta.Add("Spec.UserGroupRef", a.ko.Spec.UserGroupRef, b.ko.Spec.UserGroupRef)
 	}
 
 	return delta

--- a/pkg/resource/serverless_cache/references.go
+++ b/pkg/resource/serverless_cache/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -31,6 +32,9 @@ import (
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
@@ -45,12 +49,24 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.KMSKeyRef != nil {
+		ko.Spec.KMSKeyID = nil
+	}
+
 	if len(ko.Spec.SecurityGroupRefs) > 0 {
 		ko.Spec.SecurityGroupIDs = nil
 	}
 
+	if len(ko.Spec.SnapshotARNsToRestoreRefs) > 0 {
+		ko.Spec.SnapshotARNsToRestore = nil
+	}
+
 	if len(ko.Spec.SubnetRefs) > 0 {
 		ko.Spec.SubnetIDs = nil
+	}
+
+	if ko.Spec.UserGroupRef != nil {
+		ko.Spec.UserGroupID = nil
 	}
 
 	return &resource{ko}
@@ -72,13 +88,31 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForKMSKeyID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForSecurityGroupIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForSnapshotARNsToRestore(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForSubnetIDs(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForUserGroupID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -91,12 +125,115 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.ServerlessCache) error {
 
+	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
+	}
+
 	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroupIDs", "SecurityGroupRefs")
 	}
 
+	if len(ko.Spec.SnapshotARNsToRestoreRefs) > 0 && len(ko.Spec.SnapshotARNsToRestore) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SnapshotARNsToRestore", "SnapshotARNsToRestoreRefs")
+	}
+
 	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.SubnetIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SubnetIDs", "SubnetRefs")
+	}
+
+	if ko.Spec.UserGroupRef != nil && ko.Spec.UserGroupID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("UserGroupID", "UserGroupRef")
+	}
+	return nil
+}
+
+// resolveReferenceForKMSKeyID reads the resource referenced
+// from KMSKeyRef field and sets the KMSKeyID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ServerlessCache,
+) (hasReferences bool, err error) {
+	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.KMSKeyRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: KMSKeyRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &kmsapitypes.Key{}
+		if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.KMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Key looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Key(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *kmsapitypes.Key,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Key",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Key",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Key",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Key",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
 }
@@ -197,6 +334,102 @@ func getReferencedResourceState_SecurityGroup(
 	return nil
 }
 
+// resolveReferenceForSnapshotARNsToRestore reads the resource referenced
+// from SnapshotARNsToRestoreRefs field and sets the SnapshotARNsToRestore
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSnapshotARNsToRestore(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ServerlessCache,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.SnapshotARNsToRestoreRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SnapshotARNsToRestoreRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &svcapitypes.ServerlessCacheSnapshot{}
+			if err := getReferencedResourceState_ServerlessCacheSnapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.SnapshotARNsToRestore == nil {
+				ko.Spec.SnapshotARNsToRestore = make([]*string, 0, 1)
+			}
+			ko.Spec.SnapshotARNsToRestore = append(ko.Spec.SnapshotARNsToRestore, (*string)(obj.Status.ACKResourceMetadata.ARN))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_ServerlessCacheSnapshot looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_ServerlessCacheSnapshot(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.ServerlessCacheSnapshot,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"ServerlessCacheSnapshot",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"ServerlessCacheSnapshot",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"ServerlessCacheSnapshot",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"ServerlessCacheSnapshot",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
 // resolveReferenceForSubnetIDs reads the resource referenced
 // from SubnetRefs field and sets the SubnetIDs
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -289,6 +522,97 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name,
 			"Status.SubnetID")
+	}
+	return nil
+}
+
+// resolveReferenceForUserGroupID reads the resource referenced
+// from UserGroupRef field and sets the UserGroupID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForUserGroupID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.ServerlessCache,
+) (hasReferences bool, err error) {
+	if ko.Spec.UserGroupRef != nil && ko.Spec.UserGroupRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.UserGroupRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: UserGroupRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.UserGroup{}
+		if err := getReferencedResourceState_UserGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.UserGroupID = (*string)(obj.Spec.UserGroupID)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_UserGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_UserGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.UserGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"UserGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"UserGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"UserGroup",
+			namespace, name)
+	}
+	if obj.Spec.UserGroupID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"UserGroup",
+			namespace, name,
+			"Spec.UserGroupID")
 	}
 	return nil
 }

--- a/pkg/resource/serverless_cache/references.go
+++ b/pkg/resource/serverless_cache/references.go
@@ -57,10 +57,6 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.SecurityGroupIDs = nil
 	}
 
-	if len(ko.Spec.SnapshotARNsToRestoreRefs) > 0 {
-		ko.Spec.SnapshotARNsToRestore = nil
-	}
-
 	if len(ko.Spec.SubnetRefs) > 0 {
 		ko.Spec.SubnetIDs = nil
 	}
@@ -100,12 +96,6 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	if fieldHasReferences, err := rm.resolveReferenceForSnapshotARNsToRestore(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
 	if fieldHasReferences, err := rm.resolveReferenceForSubnetIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -131,10 +121,6 @@ func validateReferenceFields(ko *svcapitypes.ServerlessCache) error {
 
 	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroupIDs", "SecurityGroupRefs")
-	}
-
-	if len(ko.Spec.SnapshotARNsToRestoreRefs) > 0 && len(ko.Spec.SnapshotARNsToRestore) > 0 {
-		return ackerr.ResourceReferenceAndIDNotSupportedFor("SnapshotARNsToRestore", "SnapshotARNsToRestoreRefs")
 	}
 
 	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.SubnetIDs) > 0 {
@@ -330,102 +316,6 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name,
 			"Status.ID")
-	}
-	return nil
-}
-
-// resolveReferenceForSnapshotARNsToRestore reads the resource referenced
-// from SnapshotARNsToRestoreRefs field and sets the SnapshotARNsToRestore
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForSnapshotARNsToRestore(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.ServerlessCache,
-) (hasReferences bool, err error) {
-	for _, f0iter := range ko.Spec.SnapshotARNsToRestoreRefs {
-		if f0iter != nil && f0iter.From != nil {
-			hasReferences = true
-			arr := f0iter.From
-			if arr.Name == nil || *arr.Name == "" {
-				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SnapshotARNsToRestoreRefs")
-			}
-			namespace, err := ackrt.ResolveCrossNamespaceReference(
-				ctx,
-				rm.cfg.EnableCrossNamespace,
-				&ko.Status.Conditions,
-				ackrt.CrossNamespaceRefKindResource,
-				ko.ObjectMeta.GetNamespace(),
-				arr.Namespace,
-				*arr.Name,
-			)
-			if err != nil {
-				return hasReferences, err
-			}
-			obj := &svcapitypes.ServerlessCacheSnapshot{}
-			if err := getReferencedResourceState_ServerlessCacheSnapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-				return hasReferences, err
-			}
-			if ko.Spec.SnapshotARNsToRestore == nil {
-				ko.Spec.SnapshotARNsToRestore = make([]*string, 0, 1)
-			}
-			ko.Spec.SnapshotARNsToRestore = append(ko.Spec.SnapshotARNsToRestore, (*string)(obj.Status.ACKResourceMetadata.ARN))
-		}
-	}
-
-	return hasReferences, nil
-}
-
-// getReferencedResourceState_ServerlessCacheSnapshot looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_ServerlessCacheSnapshot(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *svcapitypes.ServerlessCacheSnapshot,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"ServerlessCacheSnapshot",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"ServerlessCacheSnapshot",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"ServerlessCacheSnapshot",
-			namespace, name)
-	}
-	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"ServerlessCacheSnapshot",
-			namespace, name,
-			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
 }

--- a/pkg/resource/snapshot/delta.go
+++ b/pkg/resource/snapshot/delta.go
@@ -49,6 +49,9 @@ func newResourceDelta(
 			delta.Add("Spec.CacheClusterID", a.ko.Spec.CacheClusterID, b.ko.Spec.CacheClusterID)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.CacheClusterRef, b.ko.Spec.CacheClusterRef) {
+		delta.Add("Spec.CacheClusterRef", a.ko.Spec.CacheClusterRef, b.ko.Spec.CacheClusterRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID) {
 		delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 	} else if a.ko.Spec.KMSKeyID != nil && b.ko.Spec.KMSKeyID != nil {
@@ -82,6 +85,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SourceSnapshotName != *b.ko.Spec.SourceSnapshotName {
 			delta.Add("Spec.SourceSnapshotName", a.ko.Spec.SourceSnapshotName, b.ko.Spec.SourceSnapshotName)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SourceSnapshotRef, b.ko.Spec.SourceSnapshotRef) {
+		delta.Add("Spec.SourceSnapshotRef", a.ko.Spec.SourceSnapshotRef, b.ko.Spec.SourceSnapshotRef)
 	}
 	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
 	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)

--- a/pkg/resource/snapshot/references.go
+++ b/pkg/resource/snapshot/references.go
@@ -42,12 +42,20 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.CacheClusterRef != nil {
+		ko.Spec.CacheClusterID = nil
+	}
+
 	if ko.Spec.KMSKeyRef != nil {
 		ko.Spec.KMSKeyID = nil
 	}
 
 	if ko.Spec.ReplicationGroupRef != nil {
 		ko.Spec.ReplicationGroupID = nil
+	}
+
+	if ko.Spec.SourceSnapshotRef != nil {
+		ko.Spec.SourceSnapshotName = nil
 	}
 
 	return &resource{ko}
@@ -69,6 +77,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForCacheClusterID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForKMSKeyID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -81,6 +95,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForSourceSnapshotName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -88,12 +108,111 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Snapshot) error {
 
+	if ko.Spec.CacheClusterRef != nil && ko.Spec.CacheClusterID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("CacheClusterID", "CacheClusterRef")
+	}
+
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
 	}
 
 	if ko.Spec.ReplicationGroupRef != nil && ko.Spec.ReplicationGroupID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("ReplicationGroupID", "ReplicationGroupRef")
+	}
+
+	if ko.Spec.SourceSnapshotRef != nil && ko.Spec.SourceSnapshotName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SourceSnapshotName", "SourceSnapshotRef")
+	}
+	return nil
+}
+
+// resolveReferenceForCacheClusterID reads the resource referenced
+// from CacheClusterRef field and sets the CacheClusterID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForCacheClusterID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Snapshot,
+) (hasReferences bool, err error) {
+	if ko.Spec.CacheClusterRef != nil && ko.Spec.CacheClusterRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.CacheClusterRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: CacheClusterRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.CacheCluster{}
+		if err := getReferencedResourceState_CacheCluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.CacheClusterID = (*string)(obj.Spec.CacheClusterID)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_CacheCluster looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_CacheCluster(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.CacheCluster,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"CacheCluster",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"CacheCluster",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"CacheCluster",
+			namespace, name)
+	}
+	if obj.Spec.CacheClusterID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"CacheCluster",
+			namespace, name,
+			"Spec.CacheClusterID")
 	}
 	return nil
 }
@@ -276,6 +395,97 @@ func getReferencedResourceState_ReplicationGroup(
 			"ReplicationGroup",
 			namespace, name,
 			"Spec.ReplicationGroupID")
+	}
+	return nil
+}
+
+// resolveReferenceForSourceSnapshotName reads the resource referenced
+// from SourceSnapshotRef field and sets the SourceSnapshotName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSourceSnapshotName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Snapshot,
+) (hasReferences bool, err error) {
+	if ko.Spec.SourceSnapshotRef != nil && ko.Spec.SourceSnapshotRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SourceSnapshotRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SourceSnapshotRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Snapshot{}
+		if err := getReferencedResourceState_Snapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SourceSnapshotName = (*string)(obj.Spec.SnapshotName)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Snapshot looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Snapshot(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.Snapshot,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Snapshot",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Snapshot",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Snapshot",
+			namespace, name)
+	}
+	if obj.Spec.SnapshotName == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Snapshot",
+			namespace, name,
+			"Spec.SnapshotName")
 	}
 	return nil
 }

--- a/pkg/resource/user_group/delta.go
+++ b/pkg/resource/user_group/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -66,6 +67,9 @@ func newResourceDelta(
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.UserIDs, b.ko.Spec.UserIDs) {
 			delta.Add("Spec.UserIDs", a.ko.Spec.UserIDs, b.ko.Spec.UserIDs)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.UserRefs, b.ko.Spec.UserRefs) {
+		delta.Add("Spec.UserRefs", a.ko.Spec.UserRefs, b.ko.Spec.UserRefs)
 	}
 
 	return delta

--- a/pkg/resource/user_group/references.go
+++ b/pkg/resource/user_group/references.go
@@ -17,9 +17,15 @@ package user_group
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/elasticache-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if len(ko.Spec.UserRefs) > 0 {
+		ko.Spec.UserIDs = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,121 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForUserIDs(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.UserGroup) error {
+
+	if len(ko.Spec.UserRefs) > 0 && len(ko.Spec.UserIDs) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("UserIDs", "UserRefs")
+	}
+	return nil
+}
+
+// resolveReferenceForUserIDs reads the resource referenced
+// from UserRefs field and sets the UserIDs
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForUserIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.UserGroup,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.UserRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: UserRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &svcapitypes.User{}
+			if err := getReferencedResourceState_User(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.UserIDs == nil {
+				ko.Spec.UserIDs = make([]*string, 0, 1)
+			}
+			ko.Spec.UserIDs = append(ko.Spec.UserIDs, (*string)(obj.Spec.UserID))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_User looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_User(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.User,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"User",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"User",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"User",
+			namespace, name)
+	}
+	if obj.Spec.UserID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"User",
+			namespace, name,
+			"Spec.UserID")
+	}
 	return nil
 }

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5a09bbdb961ea14a65b15b63769134125023ac61
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@e87315b032dfb8e0322ae5a1c90c0e15ea2bf5ff


### PR DESCRIPTION
Adds cross-resource references to `8` field(s) across `4` resources in `elasticache-controller`.

These fields hold another AWS resource's identifier, so today a user must hardcode a value that
does not exist until the target resource has been created. With a `references` block the user
points at the Kubernetes resource instead and the controller resolves the identifier at reconcile
time.

All targets are same-service except sns `Topic` and kms `Key`, both of which are **already** module
dependencies of this controller, so **`go.mod` and `ATTRIBUTION.md` are unchanged**.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `ReplicationGroup.NotificationTopicARN` | sns `Topic` | `Status.ACKResourceMetadata.ARN` |
| 2 | `ReplicationGroup.UserGroupIDs` | elasticache `UserGroup` | `Spec.UserGroupID` |
| 3 | `ReplicationGroup.SnapshotName` | elasticache `Snapshot` | `Spec.SnapshotName` |
| 4 | `ServerlessCache.KMSKeyID` | kms `Key` | `Status.ACKResourceMetadata.ARN` |
| 5 | `ServerlessCache.UserGroupID` | elasticache `UserGroup` | `Spec.UserGroupID` |
| 6 | `Snapshot.CacheClusterID` | elasticache `CacheCluster` | `Spec.CacheClusterID` |
| 7 | `Snapshot.SourceSnapshotName` | elasticache `Snapshot` | `Spec.SnapshotName` |
| 8 | `UserGroup.UserIDs` | elasticache `User` | `Spec.UserID` |

Two fields carry `is_immutable: true` alongside the `references` block:

- `ServerlessCache.KMSKeyID` — `KmsKeyId` is present in `CreateServerlessCacheRequest` but absent
  from `ModifyServerlessCacheRequest`, so it cannot be changed after create. This also matches the
  existing `ReplicationGroup.KMSKeyID`, `Snapshot.KMSKeyID` and `ServerlessCacheSnapshot.kmsKeyId`
  blocks.
- `ReplicationGroup.SnapshotName` — a create-time restore source, matching the `CacheCluster.SnapshotName`
  block already in this file.

No field needed `set: ignore`, `late_initialize`, or `skip_resource_state_validations`. All eight are
top-level fields, and none is written back into the spec by a Create/Update response.

**On `path` for `ServerlessCache.KMSKeyID`:** the service model is self-contradictory here —
`CreateServerlessCacheRequest.KmsKeyId` is documented as "ARN of the customer managed key" while the
`ServerlessCache.KmsKeyId` output member (what `sdkFind` reads back) says "The ID of the ... KMS key".
Since the wrong form produces a delta that never clears, this was checked against the live API rather
than the docs:

```
$ aws elasticache create-serverless-cache --serverless-cache-name ack-ref-form-probe \
    --engine valkey --kms-key-id arn:aws:kms:us-west-2:...:key/62e087d6-... [...]
{ "kms": "arn:aws:kms:us-west-2:...:key/62e087d6-d77b-46ff-af1c-c339f21c38ee" }

$ aws elasticache describe-serverless-caches --serverless-cache-name ack-ref-form-probe
{ "kms": "arn:aws:kms:us-west-2:...:key/62e087d6-d77b-46ff-af1c-c339f21c38ee" }
```

`DescribeServerlessCaches` echoes the full ARN, so `Status.ACKResourceMetadata.ARN` is correct and
the output member's "ID" wording is loose. The zero-delta result below confirms it.

### Verification

Deployed this branch to `ack-dev-auto` (`us-west-2`) with a 60s resync period
(`ack-workspace deploy elasticache --resync-period 60`) and tested each field. PASS requires all four
conditions, held delta-free across at least 3 reconciles: `ACK.ReferencesResolved=True`,
`ACK.ResourceSynced=True`, concrete field absent from `.spec`, `*Ref` present in `.spec` with the
expected target.

| # | Resource.field | RefsResolved | Synced | Concrete absent | `*Ref` present | Deltas / 4 resyncs | Result |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `ReplicationGroup.notificationTopicRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 2 | `ReplicationGroup.userGroupRefs` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 3 | `ReplicationGroup.snapshotRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 4 | `ServerlessCache.kmsKeyRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 5 | `ServerlessCache.userGroupRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 6 | `Snapshot.cacheClusterRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 7 | `Snapshot.sourceSnapshotRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 8 | `UserGroup.userRefs` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |

**Summary: 8/8 PASS** — resync period 60s, delta-free across 4 reconciles (4 ≥ 3).

> The evidence blocks below are the unedited output from that run, which also covered a ninth
> reference — `ServerlessCache.snapshotARNsToRestore` — that passed all four criteria and was then
> removed from this PR because the field is polymorphic (see [Not included](#not-included)). The
> `ec-ref-slc-restored` / `ec-ref-slc-snap` rows and the `snapshotARNsToRestoreRefs` manifest belong
> to that field. They are left in rather than trimmed so the measured output is not rewritten after
> the fact.

Every reference was also confirmed on the AWS side, so the resolved value demonstrably reached the
service rather than merely being written into the spec.

<details>
<summary>Conditions and <code>.spec</code> state per field</summary>

```
replicationgroup/ec-ref-rg: ReferencesResolved=True ResourceSynced=True
    notificationTopicARN: concrete_present=False   notificationTopicRef_present=True  value={"from": {"name": "ec-ref-topic"}}
    userGroupIDs: concrete_present=False   userGroupRefs_present=True  value=[{"from": {"name": "ec-ref-usergroup"}}]
replicationgroup/ec-ref-rg-restored: ReferencesResolved=True ResourceSynced=True
    snapshotName: concrete_present=False   snapshotRef_present=True  value={"from": {"name": "ec-ref-snapshot"}}
serverlesscache/ec-ref-slc: ReferencesResolved=True ResourceSynced=True
    kmsKeyID: concrete_present=False   kmsKeyRef_present=True  value={"from": {"name": "ec-ref-key"}}
    userGroupID: concrete_present=False   userGroupRef_present=True  value={"from": {"name": "ec-ref-usergroup"}}
serverlesscache/ec-ref-slc-restored: ReferencesResolved=True ResourceSynced=True
    snapshotARNsToRestore: concrete_present=False   snapshotARNsToRestoreRefs_present=True  value=[{"from": {"name": "ec-ref-slc-snap"}}]
snapshot/ec-ref-snapshot: ReferencesResolved=True ResourceSynced=True
    cacheClusterID: concrete_present=False   cacheClusterRef_present=True  value={"from": {"name": "ec-ref-cachecluster"}}
snapshot/ec-ref-snapshot-copy: ReferencesResolved=True ResourceSynced=True
    sourceSnapshotName: concrete_present=False   sourceSnapshotRef_present=True  value={"from": {"name": "ec-ref-snapshot"}}
usergroup/ec-ref-usergroup: ReferencesResolved=True ResourceSynced=True
    userIDs: concrete_present=False   userRefs_present=True  value=[{"from": {"name": "ec-default-user"}}, {"from": {"name": "ec-ref-user"}}]
```

</details>

<details>
<summary>AWS-side confirmation that each resolved value reached the service</summary>

```
# ReplicationGroup ec-ref-rg -> resolved sns topic ARN + user group
[ "ec-ref-usergroup" ]
arn:aws:sns:us-west-2:822779886699:ec-ref-topic
# ServerlessCache ec-ref-slc -> resolved kms ARN + user group
{ "kms": "arn:aws:kms:us-west-2:822779886699:key/6d4ce06c-8c65-4cb2-ba79-79c9f157c870",
  "userGroup": "ec-ref-usergroup" }
# Snapshot ec-ref-snapshot -> resolved source cache cluster
ec-ref-cachecluster
# Snapshot ec-ref-snapshot-copy -> copy exists (source resolved via sourceSnapshotRef)
{ "name": "ec-ref-snapshot-copy", "status": "available" }
# UserGroup ec-ref-usergroup -> resolved user IDs
[ "default", "ec-ref-user" ]
# ServerlessCache ec-ref-slc-restored -> restored from resolved snapshot ARN
available
# ReplicationGroup ec-ref-rg-restored -> restored from resolved snapshot
available
```

</details>

<details>
<summary>Reconcile count and delta measurement (4 min window at 60s resync)</summary>

Counted from the controller pod's own log, matching `requeuing` (one per completed reconcile of a
synced resource) and `desired resource state has changed`:

```
--- reconciles completed per resource ---
    4  CacheCluster/ec-ref-cachecluster
    4  CacheSubnetGroup/ec-ref-subnetgroup
    4  ReplicationGroup/ec-ref-rg
    4  ReplicationGroup/ec-ref-rg-restored
    4  ServerlessCache/ec-ref-slc
    4  ServerlessCache/ec-ref-slc-restored
    4  ServerlessCacheSnapshot/ec-ref-slc-snap
    4  Snapshot/ec-ref-snapshot
    4  Snapshot/ec-ref-snapshot-copy
    4  User/ec-default-user
    4  User/ec-ref-user
    4  UserGroup/ec-ref-usergroup
--- deltas observed ---
    4  ec-ref-rg            Spec.CacheParameterGroupName
    4  ec-ref-rg-restored   Spec.CacheParameterGroupName
```

No delta on any of the eight fields. The two `Spec.CacheParameterGroupName` entries are pre-existing
and unrelated — see the note below.

</details>

<details>
<summary>Test manifests</summary>

```yaml
# UserGroup.userRefs -> User. Note: ElastiCache requires every user group to contain the
# service-created `default` user, so that user is adopted as a CR (see operator note below).
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: UserGroup
metadata:
  name: ec-ref-usergroup
spec:
  userGroupID: ec-ref-usergroup
  engine: redis
  userRefs:
    - from: { name: ec-default-user }
    - from: { name: ec-ref-user }
---
# ServerlessCache.kmsKeyRef -> kms Key, ServerlessCache.userGroupRef -> UserGroup
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: ServerlessCache
metadata:
  name: ec-ref-slc
spec:
  serverlessCacheName: ec-ref-slc
  engine: redis
  kmsKeyRef:
    from: { name: ec-ref-key }
  userGroupRef:
    from: { name: ec-ref-usergroup }
  subnetIDs: [subnet-0509ce495da4a665a, subnet-082bf1c5de6216677]
  securityGroupIDs: [sg-047d861977a8926e7]
---
# ReplicationGroup.notificationTopicRef -> sns Topic, .userGroupRefs -> UserGroup
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: ReplicationGroup
metadata:
  name: ec-ref-rg
spec:
  replicationGroupID: ec-ref-rg
  description: ACK elasticache reference validation
  engine: redis
  cacheNodeType: cache.t3.micro
  numNodeGroups: 1
  replicasPerNodeGroup: 0
  cacheSubnetGroupName: ec-ref-subnetgroup
  securityGroupIDs: [sg-047d861977a8926e7]
  transitEncryptionEnabled: true   # required by ElastiCache when a user group is attached
  notificationTopicRef:
    from: { name: ec-ref-topic }
  userGroupRefs:
    - from: { name: ec-ref-usergroup }
---
# Snapshot.cacheClusterRef -> CacheCluster
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: Snapshot
metadata:
  name: ec-ref-snapshot
spec:
  snapshotName: ec-ref-snapshot
  cacheClusterRef:
    from: { name: ec-ref-cachecluster }
---
# Snapshot.sourceSnapshotRef -> Snapshot (self-referential Kind)
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: Snapshot
metadata:
  name: ec-ref-snapshot-copy
spec:
  snapshotName: ec-ref-snapshot-copy
  sourceSnapshotRef:
    from: { name: ec-ref-snapshot }
---
# ServerlessCache.snapshotARNsToRestoreRefs -> ServerlessCacheSnapshot
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: ServerlessCache
metadata:
  name: ec-ref-slc-restored
spec:
  serverlessCacheName: ec-ref-slc-restored
  engine: redis
  subnetIDs: [subnet-0509ce495da4a665a, subnet-082bf1c5de6216677]
  securityGroupIDs: [sg-047d861977a8926e7]
  snapshotARNsToRestoreRefs:
    - from: { name: ec-ref-slc-snap }
---
# ReplicationGroup.snapshotRef -> Snapshot
apiVersion: elasticache.services.k8s.aws/v1alpha1
kind: ReplicationGroup
metadata:
  name: ec-ref-rg-restored
spec:
  replicationGroupID: ec-ref-rg-restored
  description: ACK elasticache reference validation (restore from snapshot)
  engine: redis
  cacheNodeType: cache.t3.micro
  numNodeGroups: 1
  replicasPerNodeGroup: 0
  cacheSubnetGroupName: ec-ref-subnetgroup
  securityGroupIDs: [sg-047d861977a8926e7]
  snapshotRef:
    from: { name: ec-ref-snapshot }
```

</details>

### Notes for reviewers

**1. `UserGroup.userRefs` is all-or-nothing, and ElastiCache requires the `default` user.**
The generated `validateReferenceFields` rejects a resource that sets both the concrete list and the
ref list, so a user group is either all refs or all literals. ElastiCache separately requires every
user group to contain the user named `default`, which the service creates rather than ACK. An
operator using `userRefs` therefore has to express `default` as a CR first — adoption works:

```yaml
metadata:
  annotations:
    services.k8s.aws/adoption-policy: adopt
    services.k8s.aws/adoption-fields: '{"userID":"default"}'
```

Confirmed by first attempting a group with a single non-default `userRef`, which resolved the
reference correctly and was then rejected by AWS on its own merits:

```
ACK.ReferencesResolved=True
ACK.Terminal=True: DefaultUserRequired: Redis user group needs to contain a user with the user name default.
```

That is ElastiCache's rule, not a limitation of the reference, but it is worth documenting.

**2. A snapshot used as a restore source transiently stops being a valid reference target.**
While `ec-ref-slc-restored` / `ec-ref-rg-restored` were restoring, their source snapshots moved to
`restoring`, which drops `ACK.ResourceSynced` and makes the referencing resource report
`ACK.ReferencesResolved=Unknown: the referenced resource is not synced yet` until the restore
completes. This is the generated target-state check behaving as designed, and it self-heals — but a
user restoring from a snapshot will see that intermediate state, and after a long enough stall
controller-runtime's exponential backoff can delay recovery by several minutes.

**3. Pre-existing, unrelated: `ReplicationGroup.Spec.CacheParameterGroupName` deltas on every reconcile.**
Both replication groups logged this on all 4 reconciles, with the manifest not setting the field:

```
"diff":[{"Path":{"Parts":["Spec","CacheParameterGroupName"]},"A":null,"B":"default.redis7"}]
```

That is the "server-side default read back but never captured into the spec" pattern. The field is
untouched by this PR (its `references` block already existed and I did not set the field in any
manifest), so this is not a regression, but it means any `ReplicationGroup` that omits
`cacheParameterGroupName` diffs forever today. The fix looks like `late_initialize: {}` on
`ReplicationGroup.CacheParameterGroupName`; happy to send it separately rather than widen this PR.

<a name="not-included"></a>
### Not included

Six further fields were identified in the same audit and deliberately left out, because each needs
work this PR would not make reviewable:

| Field | Why deferred |
| --- | --- |
| `ServerlessCache.SnapshotARNsToRestore` → `ServerlessCacheSnapshot` | **Polymorphic.** A `references` block names one Kind, but the member's doc is unqualified ("The ARN(s) of the snapshot that the new serverless cache will be created from") and it reuses the `SnapshotArnsList` shape shared with `CreateCacheCluster.SnapshotArns` / `CreateReplicationGroup.SnapshotArns`, which document Amazon S3 RDB object ARNs (`arn:aws:s3:::my_bucket/snapshot1.rdb`). No pattern constrains the shape, so a `ServerlessCacheSnapshot`, a node-based `Snapshot`, and an S3 object ARN are all plausible — and the last is not wireable to any ACK Kind, since an s3 `Bucket` ARN carries no object key. Implemented and validated end-to-end (a restore from a `ServerlessCacheSnapshot` completed and held delta-free), then dropped: picking one of three targets is a design decision that deserves its own change, and the concrete field already accepts every ARN type. |
| `ReplicationGroup.PrimaryClusterId` → `CacheCluster` | Cyclic: `CacheCluster.ReplicationGroupID` already references `ReplicationGroup`, so the "target must be synced" check deadlocks both. Needs `skip_resource_state_validations` **plus** create/update hook ordering work modelled on ec2 `SecurityGroup`. |
| `CacheCluster.LogDeliveryConfigurations.DestinationDetails.CloudWatchLogsDetails.LogGroup` → cloudwatchlogs `LogGroup` | Adds a new cloudwatchlogs module dependency (and `ATTRIBUTION.md` regeneration). |
| `CacheCluster.LogDeliveryConfigurations.DestinationDetails.KinesisFirehoseDetails.DeliveryStream` → firehose `DeliveryStream` | Adds a new firehose module dependency. |
| `ReplicationGroup.LogDeliveryConfigurations.…CloudWatchLogsDetails.LogGroup` | Same dependency, plus this is a nested ref under a struct carrying `is_read_only` + `from` + `compare: is_ignored`, and `ReplicationGroup`'s delta for it is hand-written against an annotation blob (`logDeliveryRequiresUpdate`) rather than `latest`. |
| `ReplicationGroup.LogDeliveryConfigurations.…KinesisFirehoseDetails.DeliveryStream` | Same as above; shares the parent struct. |

The four log-delivery fields are naturally one follow-up PR per target service, which also keeps
each `go.mod`/`ATTRIBUTION.md` change reviewable on its own.

### Also in this PR: test-infra pin bump

The e2e job failed before collecting a single test, unrelated to this change:

```
INTERNALERROR> File ".../xdist/scheduler/each.py", line 1, in <module>
INTERNALERROR>   from py.log import Producer
INTERNALERROR> ModuleNotFoundError: No module named 'py.log'; 'py' is not a package
```

The pinned test-infra commit (`5a09bbd`) requires `pytest-xdist==2.2.0`, which imports `py.log` at
module scope in its distributed scheduler, so `pytest_configure` raises as soon as `-n` is passed.
test-infra fixed this in `d6e3816`, moving the pin to `pytest-xdist==3.5.0` (3.x dropped `py.log`).

`test/e2e/requirements.txt` is bumped to `e87315b`, which is already used by apigatewayv2,
applicationautoscaling, cloudtrail and cloudwatchlogs, and is one commit behind test-infra main
(that commit touches only Prow container images, not `acktest`).

Checked before bumping: every `acktest` symbol this suite uses exists at the new pin —
`resources.random_suffix_name`, `resources.load_resource_file`, `aws.identity.get_account_id`,
`aws.identity.get_region`, `tags`, and all nine `k8s` helpers. The failure and the fix were also
reproduced locally — `pytest-xdist==2.2.0` gives the identical `INTERNALERROR`, `3.5.0` runs clean:

```
$ pip install 'pytest-xdist==2.2.0' && pytest probe -n 2
INTERNALERROR> ... from py.log import Producer
INTERNALERROR> ModuleNotFoundError: No module named 'py.log'; 'py' is not a package

$ pip install 'pytest-xdist==3.5.0' && pytest probe -n 2
plugins: xdist-3.5.0
created: 2/2 workers
2 workers [1 item]
.                                                                        [100%]
============================== 1 passed in 0.43s ===============================
```

It rides along here because the e2e job on this PR cannot go green without it; happy to split it
into its own PR if you would rather land it separately.

### Checklist

- [x] Workspace refreshed (runtime, code-generator, controller) before generating
- [x] `service_name` omitted for same-service targets, set for cross-service
- [x] `path` matches the form the resource's Describe response returns
- [x] Regenerated with `ack-workspace build elasticache`; controller compiles
- [x] Generated artifacts committed (`apis/`, `pkg/resource/`, `config/crd/`, `helm/`)
- [x] `go.mod` unchanged (no new cross-service dependency)
- [x] `ATTRIBUTION.md` unchanged (no new module dependency)
- [x] All fields verified against the four pass criteria, delta-free across 4 reconciles

Generated with code-generator `v0.62.0` / runtime `v0.62.0`, `AWS_SDK_GO_VERSION=v1.41.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
